### PR TITLE
Track apps-script/ in version control + add college_id storage

### DIFF
--- a/apps-script/Application_Admin_Script.gs
+++ b/apps-script/Application_Admin_Script.gs
@@ -1,0 +1,980 @@
+// ============================================
+// CAMPUS READY FOUNDATION - ADMIN FUNCTIONS
+// ============================================
+// Last updated: May 19, 2026
+// Purpose: Administrative functions for Application Reviews system
+//   - Transfer approved recipients to Grant Fulfillment Database
+//   - Archive completed cohorts
+//   - Send award decision emails (winner and non-winner) to applicants
+//
+// NOTE: Variable names use ADMIN_ prefix to avoid conflicts with
+// the Application Submission script which uses CONFIG.
+
+// ============================================
+// CONFIGURATION
+// ============================================
+
+const ADMIN_GRANT_FULFILLMENT_DB_ID = '1jOOev4f8w6HzekRNRxMN6nwYfTCJ5dJKrqzK4zfcYVk';
+const ADMIN_MASTER_SHEET_NAME = 'Master';
+const ADMIN_CONFIG_TAB_NAME = 'Config Tab';
+const ADMIN_ARCHIVE_SHEET_NAME = 'Archive';
+const ADMIN_FINAL_REVIEW_SHEET_NAME = 'Final_Review';
+const ADMIN_BOARD_ESSAYS_SHEET_NAME = 'Board_Essays';
+
+// ============================================
+// MENU CREATION
+// ============================================
+
+function onOpen() {
+  const ui = SpreadsheetApp.getUi();
+
+  ui.createMenu('Grant Fulfillment')
+    .addItem('Transfer Winners to Grant Fulfillment', 'transferWinnersToGrantFulfillment')
+    .addToUi();
+
+  ui.createMenu('Archive')
+    .addItem('Archive Current Cohort', 'archiveCohort')
+    .addToUi();
+
+  ui.createMenu('CRF Admin')
+    .addItem('Import Board Scores', 'importBoardScores')
+    .addItem('Send Award Decision Emails', 'sendAwardDecisionEmails')
+    .addToUi();
+}
+
+// ============================================
+// ARCHIVE FUNCTIONS
+// ============================================
+
+/**
+ * Main archive function - archives the current cohort to the Archive tab
+ * Reads cohort year from Config Tab B1
+ */
+function archiveCohort() {
+  const ui = SpreadsheetApp.getUi();
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+  // 1. Get cohort year from Config Tab
+  const cohortYear = getCohortYearFromConfig(ss);
+  if (!cohortYear) {
+    ui.alert(
+      'Cannot Determine Cohort Year',
+      'Could not read the cohort year from Config Tab cell B1.\n\n' +
+      'Please ensure Config Tab exists and B1 contains a valid year (e.g., 2026).',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 2. Pre-flight checks
+  const masterSheet = ss.getSheetByName(ADMIN_MASTER_SHEET_NAME);
+  if (!masterSheet) {
+    ui.alert('Error', 'Master sheet not found.', ui.ButtonSet.OK);
+    return;
+  }
+
+  const finalReviewSheet = ss.getSheetByName(ADMIN_FINAL_REVIEW_SHEET_NAME);
+  if (!finalReviewSheet) {
+    ui.alert(
+      'Final_Review Tab Not Found',
+      'Cannot find the Final_Review tab.\n\n' +
+      'Please ensure the tab exists and is named exactly "Final_Review".',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 3. Ensure Archive tab exists (create if not)
+  let archiveSheet = ss.getSheetByName(ADMIN_ARCHIVE_SHEET_NAME);
+  if (!archiveSheet) {
+    archiveSheet = createArchiveTab(ss, masterSheet);
+    if (!archiveSheet) {
+      ui.alert('Error', 'Failed to create Archive tab.', ui.ButtonSet.OK);
+      return;
+    }
+  }
+
+  // 4. Check for Waitlist records
+  const waitlistCheck = checkForWaitlist(finalReviewSheet);
+  if (waitlistCheck.hasWaitlist) {
+    ui.alert(
+      'Cannot Archive: Waitlist Records Found',
+      'The following ' + waitlistCheck.count + ' student(s) are still on Waitlist:\n\n' +
+      waitlistCheck.names.join('\n') + '\n\n' +
+      'Please resolve all Waitlist records (change to Awarded or Denied) before archiving.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 5. Count records to archive
+  const recordsToArchive = getRecordsToArchive(masterSheet, cohortYear);
+  if (recordsToArchive.length === 0) {
+    ui.alert(
+      'No Records Found',
+      'No records found for the ' + cohortYear + ' cohort in the Master sheet.\n\n' +
+      'Verify Config Tab B1 contains the correct year.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 6. Build Award Status map from Final_Review
+  const awardStatusMap = buildAwardStatusMap(finalReviewSheet);
+
+  // 7. Check for missing Award Status
+  const missingStatus = [];
+  recordsToArchive.forEach(record => {
+    const appId = record.data[0]; // Column A = Application ID
+    if (!awardStatusMap[appId]) {
+      missingStatus.push(appId);
+    }
+  });
+
+  if (missingStatus.length > 0) {
+    ui.alert(
+      'Missing Award Status',
+      'The following Application IDs do not have an Award Status in Final_Review:\n\n' +
+      missingStatus.slice(0, 10).join('\n') +
+      (missingStatus.length > 10 ? '\n... and ' + (missingStatus.length - 10) + ' more' : '') +
+      '\n\nPlease ensure all applications have an Award Status (Awarded or Denied) before archiving.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 8. Confirmation dialog
+  const confirmation = ui.alert(
+    'Archive ' + recordsToArchive.length + ' Records?',
+    'You are about to archive ' + recordsToArchive.length + ' records from the ' + cohortYear + ' cohort.\n\n' +
+    'This will:\n' +
+    '• Move all application data to the Archive tab\n' +
+    '• Add Award Status (Awarded/Denied) to each record\n' +
+    '• Clear data from working tabs (Final_Review, Board_Essays)\n' +
+    '• Delete archived rows from Master\n' +
+    '• Preserve all formulas and headers\n\n' +
+    'This cannot be undone. Continue?',
+    ui.ButtonSet.YES_NO
+  );
+
+  if (confirmation !== ui.Button.YES) {
+    return;
+  }
+
+  // 9. Execute archive
+  try {
+    const result = executeArchive(ss, masterSheet, archiveSheet, recordsToArchive, awardStatusMap, cohortYear);
+
+    // 10. Success message
+    ui.alert(
+      'Archive Complete!',
+      result.archivedCount + ' records archived for the ' + cohortYear + ' cohort.\n\n' +
+      'Award breakdown:\n' +
+      '• Awarded: ' + result.awardedCount + '\n' +
+      '• Denied: ' + result.deniedCount + '\n\n' +
+      'Working tabs cleared and ready for next cohort.\n\n' +
+      'Next step: Update Config Tab B1 to ' + (cohortYear + 1) + ' when ready to begin the new cycle.',
+      ui.ButtonSet.OK
+    );
+
+    Logger.log('Archive complete: ' + result.archivedCount + ' records for cohort ' + cohortYear);
+
+  } catch (error) {
+    ui.alert(
+      'Archive Error',
+      'An error occurred during archiving:\n\n' + error.message + '\n\n' +
+      'Some data may have been partially archived. Please check the Archive tab and Master sheet.',
+      ui.ButtonSet.OK
+    );
+    Logger.log('Archive error: ' + error.message);
+  }
+}
+
+/**
+ * Creates the Archive tab with headers matching Master plus Award Status
+ */
+function createArchiveTab(ss, masterSheet) {
+  const archiveSheet = ss.insertSheet(ADMIN_ARCHIVE_SHEET_NAME);
+
+  // Get headers from Master (row 1)
+  const masterHeaders = masterSheet.getRange(1, 1, 1, masterSheet.getLastColumn()).getValues()[0];
+
+  // Add "Award Status" as the final column
+  const archiveHeaders = [...masterHeaders, 'Award Status'];
+
+  // Write headers to Archive
+  archiveSheet.getRange(1, 1, 1, archiveHeaders.length).setValues([archiveHeaders]);
+
+  // Format header row
+  const headerRange = archiveSheet.getRange(1, 1, 1, archiveHeaders.length);
+  headerRange.setFontWeight('bold');
+  headerRange.setBackground('#f3f3f3');
+
+  // Freeze header row
+  archiveSheet.setFrozenRows(1);
+
+  // Hide the sheet (Archive should be hidden by default)
+  archiveSheet.hideSheet();
+
+  Logger.log('Created Archive tab with ' + archiveHeaders.length + ' columns');
+  return archiveSheet;
+}
+
+/**
+ * Checks Final_Review for any Waitlist records
+ * Returns object with hasWaitlist, count, and names array
+ */
+function checkForWaitlist(finalReviewSheet) {
+  const result = { hasWaitlist: false, count: 0, names: [] };
+
+  // Final_Review: headers in row 3, data starts row 4
+  // Need to find Award Status column and Student Name column
+  const headerRow = 3;
+  const headers = finalReviewSheet.getRange(headerRow, 1, 1, finalReviewSheet.getLastColumn()).getValues()[0];
+
+  let awardStatusCol = -1;
+  let studentNameCol = -1;
+
+  headers.forEach((header, index) => {
+    if (header === 'Award Status') awardStatusCol = index;
+    if (header === 'Student Name') studentNameCol = index;
+  });
+
+  if (awardStatusCol === -1) {
+    Logger.log('Award Status column not found in Final_Review');
+    return result;
+  }
+
+  // Get all data rows
+  const lastRow = finalReviewSheet.getLastRow();
+  if (lastRow < 4) return result; // No data rows
+
+  const dataRange = finalReviewSheet.getRange(4, 1, lastRow - 3, finalReviewSheet.getLastColumn());
+  const data = dataRange.getValues();
+
+  data.forEach(row => {
+    if (row[awardStatusCol] === 'Waitlist') {
+      result.hasWaitlist = true;
+      result.count++;
+      if (studentNameCol !== -1 && row[studentNameCol]) {
+        result.names.push(row[studentNameCol]);
+      }
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Gets all records from Master that match the cohort year
+ * Returns array of objects with rowNumber and data array
+ */
+function getRecordsToArchive(masterSheet, cohortYear) {
+  const records = [];
+  const lastRow = masterSheet.getLastRow();
+
+  if (lastRow < 2) return records; // No data rows
+
+  // Get all data (excluding header row 1)
+  const dataRange = masterSheet.getRange(2, 1, lastRow - 1, masterSheet.getLastColumn());
+  const data = dataRange.getValues();
+
+  // Column C (index 2) is Cycle Year
+  data.forEach((row, index) => {
+    const rowCycleYear = row[2]; // Column C = Cycle Year
+    if (rowCycleYear === cohortYear || rowCycleYear === String(cohortYear)) {
+      records.push({
+        rowNumber: index + 2, // +2 because index is 0-based and we skip header
+        data: row
+      });
+    }
+  });
+
+  return records;
+}
+
+/**
+ * Builds a map of Application ID -> Award Status from Final_Review
+ */
+function buildAwardStatusMap(finalReviewSheet) {
+  const statusMap = {};
+
+  // Final_Review: headers in row 3, data starts row 4
+  const headerRow = 3;
+  const headers = finalReviewSheet.getRange(headerRow, 1, 1, finalReviewSheet.getLastColumn()).getValues()[0];
+
+  let appIdCol = -1;
+  let awardStatusCol = -1;
+
+  headers.forEach((header, index) => {
+    if (header === 'Application ID') appIdCol = index;
+    if (header === 'Award Status') awardStatusCol = index;
+  });
+
+  if (appIdCol === -1 || awardStatusCol === -1) {
+    Logger.log('Required columns not found in Final_Review');
+    return statusMap;
+  }
+
+  const lastRow = finalReviewSheet.getLastRow();
+  if (lastRow < 4) return statusMap;
+
+  const dataRange = finalReviewSheet.getRange(4, 1, lastRow - 3, finalReviewSheet.getLastColumn());
+  const data = dataRange.getValues();
+
+  data.forEach(row => {
+    const appId = row[appIdCol];
+    const status = row[awardStatusCol];
+    if (appId && status) {
+      statusMap[appId] = status;
+    }
+  });
+
+  return statusMap;
+}
+
+/**
+ * Executes the archive operation
+ * Returns object with archivedCount, awardedCount, deniedCount
+ */
+function executeArchive(ss, masterSheet, archiveSheet, recordsToArchive, awardStatusMap, cohortYear) {
+  let awardedCount = 0;
+  let deniedCount = 0;
+
+  // 1. Prepare rows for Archive (add Award Status column)
+  const archiveRows = recordsToArchive.map(record => {
+    const appId = record.data[0]; // Column A = Application ID
+    const awardStatus = awardStatusMap[appId] || 'Unknown';
+
+    if (awardStatus === 'Awarded') awardedCount++;
+    else if (awardStatus === 'Denied') deniedCount++;
+
+    return [...record.data, awardStatus];
+  });
+
+  // 2. Append to Archive tab
+  const archiveStartRow = archiveSheet.getLastRow() + 1;
+  if (archiveRows.length > 0) {
+    archiveSheet.getRange(archiveStartRow, 1, archiveRows.length, archiveRows[0].length)
+      .setValues(archiveRows);
+  }
+
+  // 3. Delete from Master (in reverse order to preserve row numbers)
+  const rowsToDelete = recordsToArchive.map(r => r.rowNumber).sort((a, b) => b - a);
+  rowsToDelete.forEach(rowNum => {
+    masterSheet.deleteRow(rowNum);
+  });
+
+  // 4. Clear subsidiary tabs
+  clearFinalReview(ss);
+  clearBoardEssays(ss);
+
+  return {
+    archivedCount: recordsToArchive.length,
+    awardedCount: awardedCount,
+    deniedCount: deniedCount
+  };
+}
+
+/**
+ * Clears Final_Review data rows (preserves headers in row 3)
+ */
+function clearFinalReview(ss) {
+  const sheet = ss.getSheetByName(ADMIN_FINAL_REVIEW_SHEET_NAME);
+  if (!sheet) return;
+
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 4) return; // No data to clear
+
+  const lastCol = sheet.getLastColumn();
+
+  // Clear rows 4 and below (data rows)
+  sheet.getRange(4, 1, lastRow - 3, lastCol).clearContent();
+
+  Logger.log('Cleared Final_Review data rows');
+}
+
+/**
+ * Clears Board_Essays score entry columns only (preserves formulas and FILTER)
+ * Surgical approach: clears only manual entry columns
+ */
+function clearBoardEssays(ss) {
+  const sheet = ss.getSheetByName(ADMIN_BOARD_ESSAYS_SHEET_NAME);
+  if (!sheet) return;
+
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 4) return; // No data to clear (header row + formula rows)
+
+  // Get headers to identify score columns
+  // Board_Essays has headers - need to find columns that are score entry columns
+  // These are typically named like "Eric Lilavois Essay 1 Score", etc.
+  // We want to preserve: Application ID (FILTER formula), and Average columns (formulas)
+
+  const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+
+  // Identify columns to clear (score entry columns contain "Score" but not "Avg")
+  const columnsToClear = [];
+  headerRow.forEach((header, index) => {
+    const headerStr = String(header);
+    // Clear columns that are individual scorer columns (contain "Essay" and "Score" but not "Avg")
+    if (headerStr.includes('Essay') && headerStr.includes('Score') && !headerStr.includes('Avg')) {
+      columnsToClear.push(index + 1); // 1-indexed
+    }
+  });
+
+  // Clear each score column (data rows only, starting at row 4)
+  // Row 3 typically has the FILTER formula, data starts row 4
+  const dataStartRow = 4;
+  const numDataRows = lastRow - dataStartRow + 1;
+
+  if (numDataRows > 0) {
+    columnsToClear.forEach(col => {
+      sheet.getRange(dataStartRow, col, numDataRows, 1).clearContent();
+    });
+  }
+
+  Logger.log('Cleared ' + columnsToClear.length + ' score columns in Board_Essays');
+}
+
+/**
+ * Gets the cohort year from Config Tab cell B1
+ */
+function getCohortYearFromConfig(ss) {
+  const configSheet = ss.getSheetByName(ADMIN_CONFIG_TAB_NAME);
+  if (!configSheet) {
+    Logger.log('Config Tab not found');
+    return null;
+  }
+
+  const yearValue = configSheet.getRange('B1').getValue();
+  if (yearValue && !isNaN(yearValue)) {
+    return parseInt(yearValue);
+  }
+
+  return null;
+}
+
+// ============================================
+// GRANT FULFILLMENT FUNCTIONS
+// ============================================
+
+/**
+ * Transfers awarded recipients from Final_Review to Grant Fulfillment Database
+ */
+function transferWinnersToGrantFulfillment() {
+  const ui = SpreadsheetApp.getUi();
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getActiveSheet();
+  const sheetName = sheet.getName();
+
+  // 1. Verify we're on a Final Review tab
+  if (!sheetName.includes('Final Review') && !sheetName.includes('Final_Review')) {
+    ui.alert(
+      'Wrong Sheet',
+      'Please run this from the Final_Review tab.\n\n' +
+      'Current sheet: ' + sheetName,
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 2. Get cohort year from Config Tab
+  const cohortYear = getCohortYearFromConfig(ss);
+  if (!cohortYear) {
+    ui.alert(
+      'Cannot Determine Cohort Year',
+      'Could not read the cohort year from Config Tab cell B1.\n\n' +
+      'Please ensure Config Tab exists and B1 contains a valid year.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 3. Get all data from current sheet
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 4) {
+    ui.alert(
+      'No Data Found',
+      'This sheet appears to be empty. Please add approved recipients first.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 4. Get column headers (Final Review has headers in row 3)
+  const headerRow = 3;
+  const headers = sheet.getRange(headerRow, 1, 1, sheet.getLastColumn()).getValues()[0];
+  const headerMap = {};
+  headers.forEach((header, index) => {
+    headerMap[header] = index;
+  });
+
+  // 5. Verify required columns exist
+  const requiredColumns = ['Student Name', 'Application ID', 'Award Status'];
+  const missingColumns = requiredColumns.filter(col => headerMap[col] === undefined);
+
+  if (missingColumns.length > 0) {
+    ui.alert(
+      'Missing Required Columns',
+      'Cannot find these required columns:\n' + missingColumns.join('\n') + '\n\n' +
+      'Please ensure your sheet has "Student Name", "Application ID", and "Award Status" columns.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // Try to find email column (could be "Email Address" or just "Email")
+  let emailCol = headerMap['Email Address'];
+  if (emailCol === undefined) {
+    emailCol = headerMap['Email'];
+  }
+
+  if (emailCol === undefined) {
+    ui.alert(
+      'Missing Email Column',
+      'Cannot find email column.\n\n' +
+      'Please ensure your sheet has either "Email Address" or "Email" column.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 6. Check if "Transferred" column exists
+  const transferredCol = headerMap['Transferred'];
+
+  // 7. Get all recipient data (data starts at row 4)
+  const dataStartRow = 4;
+  const dataRange = sheet.getRange(dataStartRow, 1, lastRow - dataStartRow + 1, sheet.getLastColumn());
+  const data = dataRange.getValues();
+
+  // 8. Filter for recipients that haven't been transferred yet
+  const newRecipients = [];
+  data.forEach((row, index) => {
+    const studentName = row[headerMap['Student Name']];
+    const applicationId = row[headerMap['Application ID']];
+    const email = row[emailCol];
+    const awardStatus = row[headerMap['Award Status']];
+
+    // Skip empty rows
+    if (!studentName || !applicationId || !email) {
+      return;
+    }
+
+    // Only transfer students with Award Status = "Awarded"
+    if (awardStatus !== 'Awarded') {
+      return;
+    }
+
+    // Check if already transferred (if column exists)
+    if (transferredCol !== undefined && row[transferredCol] === 'Yes') {
+      return;
+    }
+
+    newRecipients.push({
+      applicationId: applicationId,
+      studentName: studentName,
+      email: email,
+      rowIndex: index + dataStartRow
+    });
+  });
+
+  if (newRecipients.length === 0) {
+    ui.alert(
+      'No New Recipients',
+      'All recipients in this sheet have already been transferred.\n\n' +
+      'If you need to add more recipients, add them to this sheet first.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 9. Confirm with user
+  const confirmation = ui.alert(
+    'Transfer ' + newRecipients.length + ' Recipients?',
+    'You are about to transfer ' + newRecipients.length + ' approved recipients from the ' +
+    cohortYear + ' cohort to Grant Fulfillment Database.\n\n' +
+    'These students will be able to access the kit customization form.\n\n' +
+    'Continue?',
+    ui.ButtonSet.YES_NO
+  );
+
+  if (confirmation !== ui.Button.YES) {
+    return;
+  }
+
+  // 10. Open Grant Fulfillment Database
+  let gfDatabase;
+  try {
+    gfDatabase = SpreadsheetApp.openById(ADMIN_GRANT_FULFILLMENT_DB_ID);
+  } catch (error) {
+    ui.alert(
+      'Cannot Access Grant Fulfillment Database',
+      'Error: ' + error.message + '\n\n' +
+      'Please verify:\n' +
+      '1. The ADMIN_GRANT_FULFILLMENT_DB_ID is correct in the script\n' +
+      '2. You have edit access to the Grant Fulfillment Database\n' +
+      '3. The file has not been deleted or moved',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 11. Get Grant_Recipients sheet
+  let grantRecipientsSheet = gfDatabase.getSheetByName('Grant_Recipients');
+
+  if (!grantRecipientsSheet) {
+    ui.alert(
+      'Grant_Recipients Tab Not Found',
+      'The Grant_Recipients tab does not exist in the Grant Fulfillment Database.\n\n' +
+      'Please create it first following the setup instructions.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 12. Get Start Dates from Master sheet
+  const masterSheet = ss.getSheetByName(ADMIN_MASTER_SHEET_NAME);
+  const startDateMap = {};
+  const phoneMap = {};
+
+  if (masterSheet) {
+    const masterData = masterSheet.getDataRange().getValues();
+    const masterHeaders = masterData[0];
+    const appIdCol = masterHeaders.indexOf('Application ID');
+    const startDateCol = masterHeaders.indexOf('Expected Start Date');
+
+    const phoneCol = masterHeaders.indexOf('Student Phone');
+
+    if (appIdCol !== -1 && startDateCol !== -1) {
+      for (let i = 1; i < masterData.length; i++) {
+        const appId = masterData[i][appIdCol];
+        const startDate = masterData[i][startDateCol];
+        if (appId && startDate) {
+          startDateMap[appId] = Utilities.formatDate(new Date(startDate), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+        }
+        if (appId && phoneCol !== -1 && masterData[i][phoneCol]) {
+          phoneMap[appId] = masterData[i][phoneCol];
+        }
+      }
+    }
+  }
+
+  // 13. Prepare data for Grant_Recipients
+  const today = new Date();
+  const transferDate = Utilities.formatDate(today, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+
+  const rowsToAdd = newRecipients.map(recipient => [
+    recipient.applicationId,                          // A: Application ID
+    recipient.studentName,                            // B: Student Name
+    recipient.email,                                  // C: Email Address
+    cohortYear,                                       // D: Cohort Year
+    transferDate,                                     // E: Transfer Date
+    'Pending',                                        // F: Housing Status
+    '',                                               // G: Housing Doc URL
+    'Pending',                                        // H: Acceptance Status
+    '',                                               // I: Acceptance Doc URL
+    'No',                                             // J: Items Selected
+    '',                                               // K: Submission Timestamp
+    '',                                               // L: Rejection Email Sent
+    '',                                               // M: Rejection Count
+    startDateMap[recipient.applicationId] || '',      // N: Start Date
+    '',                                               // O: Testimonial Invited
+    '',                                               // P: Submission URL
+    '',                                               // Q: Release Signed
+    '',                                               // R: Gift Card Sent
+    phoneMap[recipient.applicationId] || ''           // S: Phone
+  ]);
+
+  // 14. Append to Grant_Recipients
+  try {
+    const startRow = grantRecipientsSheet.getLastRow() + 1;
+grantRecipientsSheet.getRange(startRow, 1, rowsToAdd.length, 19).setValues(rowsToAdd);
+  } catch (error) {
+    ui.alert(
+      'Error Writing to Grant_Recipients',
+      'Error: ' + error.message + '\n\n' +
+      'The transfer was not completed. No data was changed.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 15. Mark as transferred
+  if (transferredCol !== undefined) {
+    newRecipients.forEach(recipient => {
+      sheet.getRange(recipient.rowIndex, transferredCol + 1).setValue('Yes');
+    });
+  } else {
+    const lastCol = sheet.getLastColumn();
+    sheet.getRange(headerRow, lastCol + 1).setValue('Transferred');
+    newRecipients.forEach(recipient => {
+      sheet.getRange(recipient.rowIndex, lastCol + 1).setValue('Yes');
+    });
+  }
+
+  // 16. Success message
+  ui.alert(
+    'Transfer Complete!',
+    newRecipients.length + ' recipients successfully transferred to Grant Fulfillment Database.\n\n' +
+    'Cohort: ' + cohortYear + '\n' +
+    'Date: ' + transferDate + '\n\n' +
+    'These students can now access the kit customization form once they receive their notification email.',
+    ui.ButtonSet.OK
+  );
+
+  Logger.log('Transfer complete: ' + newRecipients.length + ' recipients transferred for cohort ' + cohortYear);
+}
+
+// ============================================
+// AWARD DECISION EMAILS
+// ============================================
+
+function sendAwardDecisionEmails() {
+  const ui = SpreadsheetApp.getUi();
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Final_Review');
+
+  if (!sheet) {
+    ui.alert('Error', 'Final_Review tab not found.', ui.ButtonSet.OK);
+    return;
+  }
+
+  const headerRow = 3;
+  const dataStartRow = 4;
+  const headers = sheet.getRange(headerRow, 1, 1, sheet.getLastColumn()).getValues()[0];
+  const headerMap = {};
+  headers.forEach((h, i) => { headerMap[h] = i; });
+
+  // Locate required columns
+  const nameCol = headerMap['Student Name'];
+  const emailCol = headerMap['Email Address'] !== undefined ? headerMap['Email Address'] : headerMap['Email'];
+  const awardStatusCol = headerMap['Award Status'];
+  let emailSentCol = headerMap['Award Email Sent'];
+
+  // Create Award Email Sent column if it doesn't exist
+  if (emailSentCol === undefined) {
+    const newCol = sheet.getLastColumn() + 1;
+    sheet.getRange(headerRow, newCol).setValue('Award Email Sent');
+    emailSentCol = newCol - 1; // convert to 0-based index
+  }
+
+  if (nameCol === undefined || emailCol === undefined || awardStatusCol === undefined) {
+    ui.alert('Missing Columns', 'Could not find required columns: Student Name, Email, Award Status.', ui.ButtonSet.OK);
+    return;
+  }
+
+  const lastRow = sheet.getLastRow();
+  if (lastRow < dataStartRow) {
+    ui.alert('No Data', 'No student records found in Final_Review.', ui.ButtonSet.OK);
+    return;
+  }
+
+  const data = sheet.getRange(dataStartRow, 1, lastRow - dataStartRow + 1, sheet.getLastColumn()).getValues();
+
+  // Build send list
+  const toSend = [];
+  data.forEach((row, i) => {
+    const name = row[nameCol];
+    const email = row[emailCol];
+    const status = row[awardStatusCol];
+    const alreadySent = row[emailSentCol];
+
+    if (!name || !email) return;
+    if (status !== 'Awarded' && status !== 'Denied') return;
+    if (alreadySent === 'Yes') return;
+
+    toSend.push({
+      rowIndex: i + dataStartRow,
+      firstName: name.toString().split(' ')[0],
+      email: email.toString(),
+      status: status
+    });
+  });
+
+  if (toSend.length === 0) {
+    ui.alert('Nothing to Send', 'No eligible students found. All may have already been notified, or no Award Status has been set.', ui.ButtonSet.OK);
+    return;
+  }
+
+  const winners = toSend.filter(s => s.status === 'Awarded').length;
+  const nonWinners = toSend.filter(s => s.status === 'Denied').length;
+
+  const confirm = ui.alert(
+    'Send Award Decision Emails?',
+    'Ready to send ' + toSend.length + ' email(s):\n\n• Winner emails: ' + winners + '\n• Non-winner emails: ' + nonWinners + '\n\nThis cannot be undone. Continue?',
+    ui.ButtonSet.YES_NO
+  );
+
+  if (confirm !== ui.Button.YES) return;
+
+  let successCount = 0;
+  let failCount = 0;
+  const timestamp = new Date();
+
+  toSend.forEach(student => {
+    try {
+      if (student.status === 'Awarded') {
+        sendWinnerEmail(student.firstName, student.email);
+      } else {
+        sendNonWinnerEmail(student.firstName, student.email);
+      }
+      // Mark as sent
+      sheet.getRange(student.rowIndex, emailSentCol + 1).setValue('Yes');
+      sheet.getRange(student.rowIndex, emailSentCol + 2).setValue(timestamp);
+      successCount++;
+      Logger.log('Award email sent (' + student.status + '): ' + student.email);
+    } catch (error) {
+      failCount++;
+      Logger.log('Failed to send to ' + student.email + ': ' + error.message);
+    }
+  });
+
+  let summary = successCount + ' email(s) sent successfully.';
+  if (failCount > 0) summary += '\n' + failCount + ' failed — check Logs for details.';
+
+  ui.alert('Done', summary, ui.ButtonSet.OK);
+}
+
+function sendWinnerEmail(firstName, email) {
+  const subject = 'Congratulations from Campus Ready Foundation';
+
+  const htmlBody = '<!DOCTYPE html>\n' +
+'<html lang="en">\n' +
+'<head>\n' +
+'  <meta charset="UTF-8">\n' +
+'  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+'  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">\n' +
+'</head>\n' +
+'<body style="margin:0;padding:0;background:#f9fafb;font-family:\'Inter\',-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">\n' +
+'  <div style="max-width:600px;margin:0 auto;background:#ffffff;border-radius:12px;overflow:hidden;">\n' +
+'\n' +
+'    <div style="background:#469E92;padding:40px 32px;text-align:center;">\n' +
+'      <p style="font-family:\'Playfair Display\',Georgia,serif;font-size:32px;font-weight:700;color:#ffffff;margin:0;letter-spacing:-0.5px;">You\'re in!</p>\n' +
+'    </div>\n' +
+'\n' +
+'    <div style="padding:32px;font-size:15px;line-height:1.7;color:#231F20;">\n' +
+'      <p style="margin:0 0 20px;">Congratulations ' + firstName + ',</p>\n' +
+'      <p style="margin:0 0 24px;">You\'ve earned a Campus Ready Foundation grant.</p>\n' +
+'\n' +
+'      <p style="font-weight:600;margin:0 0 12px;font-size:17px;">Here\'s what you\'ll be receiving</p>\n' +
+'\n' +
+'      <table style="width:100%;margin:0 0 28px;border-collapse:collapse;">\n' +
+'        <tr><td style="padding:6px 0;vertical-align:top;width:12px;"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#469E92;margin-top:7px;"></span></td><td style="padding:6px 0 6px 10px;"><strong>Move-in essentials, personalized for you:</strong> bedding, towels, personal care items, and room basics, chosen around your style and preferences and delivered before move-in</td></tr>\n' +
+'        <tr><td style="padding:6px 0;vertical-align:top;width:12px;"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#469E92;margin-top:7px;"></span></td><td style="padding:6px 0 6px 10px;"><strong>Travel support</strong> to help cover the cost of getting to campus</td></tr>\n' +
+'        <tr><td style="padding:6px 0;vertical-align:top;width:12px;"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#469E92;margin-top:7px;"></span></td><td style="padding:6px 0 6px 10px;"><strong>DoorDash credits</strong> for your first days: meals and groceries while you\'re getting settled</td></tr>\n' +
+'        <tr><td style="padding:6px 0;vertical-align:top;width:12px;"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#469E92;margin-top:7px;"></span></td><td style="padding:6px 0 6px 10px;"><strong>A gift card for incidentals:</strong> because there\'s always something else you need</td></tr>\n' +
+'      </table>\n' +
+'\n' +
+'      <p style="font-weight:600;margin:0 0 16px;font-size:17px;">Here\'s what happens next</p>\n' +
+'\n' +
+'      <table style="width:100%;border:1px solid #e5e7eb;border-radius:12px;border-collapse:separate;border-spacing:0;margin:0 0 28px;overflow:hidden;">\n' +
+'        <tr>\n' +
+'          <td style="padding:16px 20px;vertical-align:top;border-bottom:1px solid #e5e7eb;width:80px;font-weight:600;font-size:13px;color:#469E92;white-space:nowrap;">July 1</td>\n' +
+'          <td style="padding:16px 20px;font-size:14px;border-bottom:1px solid #e5e7eb;">We\'ll send you a link to upload two documents: your housing confirmation and your college acceptance letter. Once we\'ve approved them, we\'ll send you a preferences form to help us personalize your products.</td>\n' +
+'        </tr>\n' +
+'        <tr>\n' +
+'          <td style="padding:16px 20px;vertical-align:top;border-bottom:1px solid #e5e7eb;width:80px;font-weight:600;font-size:13px;color:#469E92;white-space:nowrap;">July 15</td>\n' +
+'          <td style="padding:16px 20px;font-size:14px;border-bottom:1px solid #e5e7eb;">Join us for our Orientation &amp; Celebration, where you\'ll meet the team, finalize your award details, and hear everything you need to know about move-in. You can attend in person or on Zoom. Details coming soon. Save the date.</td>\n' +
+'        </tr>\n' +
+'        <tr>\n' +
+'          <td style="padding:16px 20px;vertical-align:top;width:80px;font-weight:600;font-size:13px;color:#469E92;line-height:1.4;">2 weeks before move-in</td>\n' +
+'          <td style="padding:16px 20px;font-size:14px;">Your items arrive.</td>\n' +
+'        </tr>\n' +
+'      </table>\n' +
+'\n' +
+'      <p style="margin:0 0 20px;">Questions before then? Reach us at <a href="mailto:hello@campusready.org" style="color:#469E92;text-decoration:none;">hello@campusready.org</a>.</p>\n' +
+'      <p style="margin:0 0 32px;">We\'re proud of you, and we\'ll be in touch. Now, have a great summer!</p>\n' +
+'\n' +
+'      <div style="border-top:1px solid #e5e7eb;padding-top:24px;">\n' +
+'        <p style="margin:0 0 4px;font-weight:600;">The Campus Ready Foundation Team</p>\n' +
+'      </div>\n' +
+'    </div>\n' +
+'  </div>\n' +
+'</body>\n' +
+'</html>';
+
+  const textBody = 'Congratulations ' + firstName + ',\n\n' +
+'You\'ve earned a Campus Ready Foundation grant.\n\n' +
+'Here\'s what you\'ll be receiving:\n' +
+'• Move-in essentials, personalized for you: bedding, towels, personal care items, and room basics\n' +
+'• Travel support to help cover the cost of getting to campus\n' +
+'• DoorDash credits for your first days\n' +
+'• A gift card for incidentals\n\n' +
+'Here\'s what happens next:\n\n' +
+'July 1 — We\'ll send you a link to upload your housing confirmation and college acceptance letter. Once approved, we\'ll send you a preferences form.\n\n' +
+'July 15 — Join us for our Orientation & Celebration. In person or Zoom. Details coming soon.\n\n' +
+'2 weeks before move-in — Your items arrive.\n\n' +
+'Questions? hello@campusready.org\n\n' +
+'We\'re proud of you, and we\'ll be in touch. Now, have a great summer!\n\n' +
+'The Campus Ready Foundation Team';
+
+  GmailApp.sendEmail(email, subject, textBody, {
+    htmlBody: htmlBody,
+    name: 'Campus Ready Foundation',
+    from: 'hello@campusready.org',
+    replyTo: 'hello@campusready.org'
+  });
+}
+
+function sendNonWinnerEmail(firstName, email) {
+  const subject = 'Campus Ready Foundation';
+
+  const htmlBody = '<!DOCTYPE html>\n' +
+'<html lang="en">\n' +
+'<head>\n' +
+'  <meta charset="UTF-8">\n' +
+'  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+'  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">\n' +
+'</head>\n' +
+'<body style="margin:0;padding:0;background:#f9fafb;font-family:\'Inter\',-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">\n' +
+'  <div style="max-width:600px;margin:0 auto;background:#ffffff;border-radius:12px;overflow:hidden;">\n' +
+'\n' +
+'    <div style="background:#469E92;padding:40px 32px;text-align:center;">\n' +
+'      <p style="font-family:\'Playfair Display\',Georgia,serif;font-size:32px;font-weight:700;color:#ffffff;margin:0;letter-spacing:-0.5px;">Thank you for applying.</p>\n' +
+'    </div>\n' +
+'\n' +
+'    <div style="padding:32px;font-size:15px;line-height:1.7;color:#231F20;">\n' +
+'      <p style="margin:0 0 20px;">Hi ' + firstName + ',</p>\n' +
+'      <p style="margin:0 0 20px;">After a careful review of all applications, we are not able to offer you a grant this cycle.</p>\n' +
+'      <p style="margin:0 0 20px;">This was not an easy decision. Every application we received represented a real student with real needs, and yours was no exception. We\'re grateful you trusted us with your story.</p>\n' +
+'      <p style="margin:0 0 32px;">We\'re rooting for you. College is a big step, and we hope your first year is everything you worked for.</p>\n' +
+'\n' +
+'      <div style="border-top:1px solid #e5e7eb;padding-top:24px;">\n' +
+'        <p style="margin:0 0 4px;color:#6b7280;font-size:14px;">Have a great summer,</p>\n' +
+'        <p style="margin:0 0 4px;font-weight:600;">The Campus Ready Foundation Team</p>\n' +
+'        <a href="https://campusready.org" style="color:#469E92;text-decoration:none;font-size:14px;">campusready.org</a>\n' +
+'      </div>\n' +
+'    </div>\n' +
+'  </div>\n' +
+'</body>\n' +
+'</html>';
+
+  const textBody = 'Hi ' + firstName + ',\n\n' +
+'After a careful review of all applications, we are not able to offer you a grant this cycle.\n\n' +
+'This was not an easy decision. Every application we received represented a real student with real needs, and yours was no exception. We\'re grateful you trusted us with your story.\n\n' +
+'We\'re rooting for you. College is a big step, and we hope your first year is everything you worked for.\n\n' +
+'Have a great summer,\n' +
+'The Campus Ready Foundation Team\n' +
+'campusready.org';
+
+  GmailApp.sendEmail(email, subject, textBody, {
+    htmlBody: htmlBody,
+    name: 'Campus Ready Foundation',
+    from: 'hello@campusready.org',
+    replyTo: 'hello@campusready.org'
+  });
+}
+
+function testWinnerEmail() {
+  sendWinnerEmail('Eric', 'eric@campusready.org');
+  Logger.log('Test winner email sent to eric@campusready.org');
+}
+
+function testNonWinnerEmail() {
+  sendNonWinnerEmail('Eric', 'eric@campusready.org');
+  Logger.log('Test non-winner email sent to eric@campusready.org');
+}
+
+// ============================================
+// END OF SCRIPT
+// ============================================

--- a/apps-script/Application_Main_Script.gs
+++ b/apps-script/Application_Main_Script.gs
@@ -1,0 +1,1754 @@
+// === CAMPUS READY FOUNDATION - APPLICATION SUBMISSION SCRIPT ===
+// Version 3.0 - Sync/Async Refactor
+// Changes from 2.1:
+//   - doPost now returns in <3 seconds (no PDF, Maps, or email during submission)
+//   - Background trigger generates PDF, calculates distance, sends confirmation email
+//   - Duplicate detection: one application per email per cycle year
+//   - Daily staff digest replaces per-submission staff notifications
+//   - Rate-limited error alerts to apply@campusready.org
+//   - Stuck-row sweeper recovers background failures
+//
+// Before using: run installTriggers() once from the editor to install the
+// three time-driven triggers (queue processor, stuck-row sweeper, daily digest).
+
+// === CONFIGURATION ===
+const CONFIG = {
+  SPREADSHEET_ID: '1utgR5xiHElarYMAj-jg_ReY7ZQMrzqFYb6wKOCPWB4s',
+  STAFF_EMAILS: ['apply@campusready.org', 'kdantzler@gmail.com', 'jg4art@aol.com'],
+  REDIRECT_URL: 'https://campusready.org',
+  PDF_FOLDER_ID: '1H7EQRF29pNp5r8NKJqDoz1HK92FyE1xW',
+  MASTER_SHEET_NAME: 'Master',
+  PENDING_DATA_SHEET_NAME: 'PendingData',
+  GOOGLE_MAPS_API_KEY: 'AIzaSyCYL-tBCsyCGplPy2Dmrk27Ro-RiXR1r3Y',
+  // v3.0 additions:
+  ALERT_EMAIL: 'eric@campusready.org',
+  BATCH_SIZE: 15,                         // Max rows processed per background run
+  BATCH_WALL_CLOCK_MS: 270000,            // 4.5 min safety under 6 min Apps Script cap
+  STUCK_ROW_MINUTES: 15,                  // Rows stuck in Processing longer than this get recovered
+  SYNC_LOCK_TIMEOUT_MS: 10000,            // doPost lock wait ceiling
+  CLAIM_LOCK_TIMEOUT_MS: 5000,            // Background claim lock wait ceiling
+  ALERT_RATE_LIMIT_MS: 3600000,           // 1 hour per unique alert signature
+  EMAIL_RETRY_ATTEMPTS: 3,                // Exponential backoff on confirmation email
+  DIGEST_TIMEZONE: 'America/Los_Angeles',
+  DIGEST_HOUR: 7                          // 7am Pacific
+};
+
+// === COLUMN POSITIONS (Master sheet, 1-indexed) ===
+// These are constants for clarity. Master column order is fixed - do not change.
+const COL = {
+  APP_ID: 1,              // A
+  TIMESTAMP: 2,           // B
+  CYCLE_YEAR: 3,          // C
+  STUDENT_NAME: 10,       // J
+  STUDENT_EMAIL: 11,      // K
+  COLLEGE: 18,            // R
+  HOUSEHOLD_MEMBERS: 24,  // X
+  HOUSEHOLD_INCOME: 25,   // Y
+  PDF_URL: 35,            // AI
+  PDF_FILE_ID: 36,        // AJ
+  STATUS: 37,             // AK
+  PROCESSING_STARTED: 38, // AL - timestamp when row was claimed by background worker
+  DISTANCE: 39,           // AM
+  // Columns AN (40) through AW (49) are scoring/derived data managed by
+  // staff, formulas, and Board_Score_Import — the row writer does NOT touch
+  // them. Distance Points, Circumstances Points, Financial Needs Points,
+  // Essay 1/2 Scores, Housing Verified, Total Score, New Rank, Income Per
+  // Person, Avg Essay Score.
+  COLLEGE_ID: 50          // AX - IPEDS UNITID from the college picker (Phase 2)
+};
+
+// === MAIN ENTRY POINT (SYNC PATH) ===
+// Target runtime: under 3 seconds.
+// Responsibilities: parse, lock, dedup check, write Master + PendingData, return success.
+// Everything else (PDF, distance, email) runs in processBackgroundQueue().
+function doPost(e) {
+  const t0 = Date.now();
+  try {
+    console.log('=== NEW APPLICATION SUBMISSION ===');
+
+    const data = parseFormData(e);
+    console.log('Parsed data for:', data.student_name);
+
+    const lock = LockService.getScriptLock();
+    if (!lock.tryLock(CONFIG.SYNC_LOCK_TIMEOUT_MS)) {
+      console.error('Could not acquire script lock within ' + CONFIG.SYNC_LOCK_TIMEOUT_MS + 'ms');
+      return createErrorPage(new Error('The system is experiencing heavy load. Please wait a moment and try again.'));
+    }
+
+    let applicationId = null;
+    let existingAppId = null;
+
+    try {
+      const cycleYear = computeCycleYear(new Date());
+      existingAppId = checkForDuplicate(data.student_email, cycleYear);
+
+      if (!existingAppId) {
+        applicationId = generateApplicationId();
+        console.log('Generated ID:', applicationId);
+
+        const rowNumber = writeMasterRowPending(data, applicationId);
+        console.log('Written to Master row:', rowNumber);
+
+        writePendingData(applicationId, data);
+        console.log('Pending data stored');
+      }
+    } finally {
+      lock.releaseLock();
+    }
+
+    const elapsed = Date.now() - t0;
+    console.log('PERF doPost total(ms): ' + elapsed);
+
+    if (existingAppId) {
+      console.log('Duplicate detected. Existing App ID:', existingAppId);
+      return createAlreadySubmittedPage(existingAppId, data);
+    }
+
+    return createSuccessPage(data, applicationId);
+
+  } catch (error) {
+    console.error('doPost error:', error);
+    return createErrorPage(error);
+  }
+}
+
+// === DUPLICATE DETECTION ===
+// Returns existing App ID if this email has already submitted for this cycle year.
+// Returns null otherwise. Called inside the LockService block.
+function checkForDuplicate(email, cycleYear) {
+  if (!email) return null;
+  const normalized = String(email).trim().toLowerCase();
+  if (!normalized) return null;
+
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return null;
+
+  // Read columns A through K in a single range get (App ID + Cycle Year + Email)
+  const values = sheet.getRange(2, 1, lastRow - 1, 11).getValues();
+
+  for (let i = 0; i < values.length; i++) {
+    const rowAppId = values[i][0];
+    const rowCycleYear = values[i][2];
+    const rowEmail = String(values[i][10] || '').trim().toLowerCase();
+
+    if (!rowEmail) continue;
+
+    const yearMatches = rowCycleYear === cycleYear || rowCycleYear === String(cycleYear);
+    if (yearMatches && rowEmail === normalized) {
+      return rowAppId;
+    }
+  }
+  return null;
+}
+
+// === MASTER SHEET WRITING (SYNC) ===
+// Writes the row with Status="Pending Processing" and empty PDF URL/Distance.
+// Background processor fills those in later.
+function writeMasterRowPending(data, applicationId) {
+  const sheet = getMasterSheet();
+  const targetRow = findNextAvailableRow(sheet);
+  const submissionTs = new Date();
+  const cycleYear = computeCycleYear(submissionTs);
+
+  const rowData = [
+    applicationId,                                     // A: Application ID
+    submissionTs,                                      // B: Submission Timestamp
+    cycleYear,                                         // C: Cycle Year
+    data.applicant_typed_name || '',                   // D: Applicant Typed Name
+    toBool(data.applicantSignature),                   // E: Applicant Signed
+    isGuardianRequired(data),                          // F: Guardian Required
+    data.guardian_typed_name || '',                    // G: Guardian Typed Name
+    toBool(data.guardianSignature),                    // H: Guardian Signed
+    getConsentSentence(data),                          // I: Consent Sentence
+    data.student_name || '',                           // J: Student Full Name
+    data.student_email || '',                          // K: Student Email
+    data.student_phone || '',                          // L: Student Phone
+    data.student_dob || '',                            // M: Date of Birth
+    data.student_address || '',                        // N: Home Address
+    data.student_city_name || '',                      // O: Home City
+    data.student_state || '',                          // P: Home State
+    data.student_zip || '',                            // Q: Home ZIP
+    data.college || '',                                // R: College Name
+    data.college_address || '',                        // S: College Address — empty for 2027+ (field removed in Phase 2)
+    data.college_city_name || '',                      // T: College City
+    data.college_state || '',                          // U: College State
+    data.college_zip || '',                            // V: College ZIP
+    data.start_date || '',                             // W: Expected Start Date
+    parseInt(data.household_members) || 0,             // X: Household Members
+    cleanIncomeValue(data.household_income),           // Y: Household Income
+    data.fafsa || '',                                  // Z: FAFSA Completed
+    parseFloat(data.sai) || 0,                         // AA: SAI
+    buildHouseholdCircumstances(data),                 // AB: Circumstances
+    data.accompany || '',                              // AC: Will Accompany to Campus
+    buildAffordabilityConcerns(data),                  // AD: Concerns
+    data.other_concern_text || '',                     // AE: Other Concern Text
+    truncateText(data.essay1, 75),                     // AF: Essay 1 Snippet
+    truncateText(data.essay2, 75),                     // AG: Essay 2 Snippet
+    countWords(data.essay2),                           // AH: Essay 2 Word Count
+    '',                                                // AI: PDF URL (filled by background)
+    '',                                                // AJ: PDF File ID (filled by background)
+    'Pending Processing',                              // AK: Status
+    '',                                                // AL: Processing Started timestamp (set by claimRow)
+    ''                                                 // AM: Distance (filled by background)
+  ];
+  sheet.getRange(targetRow, 1, 1, rowData.length).setValues([rowData]);
+
+  // Columns AN (40) through AW (49) are scoring/derived data — do not touch.
+  // College UNITID lives at AX (50), past the scoring block, written as a
+  // separate single-cell update so the main row array stays at 39 columns
+  // and cannot accidentally overwrite a scoring formula or staff entry.
+  if (data.college_id) {
+    sheet.getRange(targetRow, COL.COLLEGE_ID).setValue(data.college_id);
+  }
+
+  return targetRow;
+}
+
+// === PENDING DATA STORAGE ===
+// A hidden "PendingData" tab stores the full raw form JSON keyed by App ID.
+// The background processor reads it, generates the PDF (which needs full essays),
+// then deletes the row. Signatures are stripped because they're not used in the PDF.
+function getPendingDataSheet() {
+  const ss = SpreadsheetApp.openById(CONFIG.SPREADSHEET_ID);
+  let sheet = ss.getSheetByName(CONFIG.PENDING_DATA_SHEET_NAME);
+  if (!sheet) {
+    sheet = ss.insertSheet(CONFIG.PENDING_DATA_SHEET_NAME);
+    sheet.getRange(1, 1, 1, 2).setValues([['Application ID', 'Raw Data JSON']]);
+    sheet.setFrozenRows(1);
+    sheet.hideSheet();
+    console.log('Created PendingData sheet');
+  }
+  return sheet;
+}
+
+function writePendingData(applicationId, data) {
+  const sheet = getPendingDataSheet();
+  // Strip heavy signature data (never used in PDF, blows cell size budget if kept)
+  const slim = Object.assign({}, data);
+  delete slim.applicantSignature;
+  delete slim.guardianSignature;
+
+  const json = JSON.stringify(slim);
+  if (json.length > 45000) {
+    console.warn('PendingData JSON unusually large: ' + json.length + ' chars for ' + applicationId);
+  }
+  sheet.appendRow([applicationId, json]);
+}
+
+function readPendingData(applicationId) {
+  const sheet = getPendingDataSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return null;
+
+  const values = sheet.getRange(2, 1, lastRow - 1, 2).getValues();
+  for (let i = 0; i < values.length; i++) {
+    if (values[i][0] === applicationId) {
+      try {
+        return { rowNumber: i + 2, data: JSON.parse(values[i][1]) };
+      } catch (err) {
+        console.error('Failed to parse PendingData for ' + applicationId + ': ' + err.message);
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function deletePendingData(applicationId) {
+  const sheet = getPendingDataSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return;
+
+  const ids = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
+  // Walk from the bottom so deleteRow doesn't shift indexes we still need
+  for (let i = ids.length - 1; i >= 0; i--) {
+    if (ids[i][0] === applicationId) {
+      sheet.deleteRow(i + 2);
+      return;
+    }
+  }
+}
+
+// === BACKGROUND QUEUE PROCESSOR ===
+// Trigger: every 1 minute.
+// Picks up "Pending Processing" rows, claims them atomically, does PDF + Maps + email,
+// then flips Status to "Submitted". Failures mark Status="Failed: <reason>" and alert Eric.
+function processBackgroundQueue() {
+  const startTime = Date.now();
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return;
+
+  const appIds = sheet.getRange(2, COL.APP_ID, lastRow - 1, 1).getValues();
+  const statuses = sheet.getRange(2, COL.STATUS, lastRow - 1, 1).getValues();
+
+  const pendingRows = [];
+  for (let i = 0; i < statuses.length; i++) {
+    if (statuses[i][0] === 'Pending Processing') {
+      pendingRows.push({ rowNumber: i + 2, applicationId: appIds[i][0] });
+    }
+  }
+
+  if (pendingRows.length === 0) return;
+  console.log('Background queue: ' + pendingRows.length + ' pending rows');
+
+  let processed = 0, failed = 0;
+
+  for (let i = 0; i < Math.min(pendingRows.length, CONFIG.BATCH_SIZE); i++) {
+    // Wall-clock safety: leave margin under the 6-min execution limit
+    if (Date.now() - startTime > CONFIG.BATCH_WALL_CLOCK_MS) {
+      console.log('Wall-clock limit approaching, stopping after ' + processed + ' processed');
+      break;
+    }
+
+    const row = pendingRows[i];
+    if (!claimRow(sheet, row.rowNumber)) {
+      console.log('Row ' + row.rowNumber + ' not claimable (already taken)');
+      continue;
+    }
+
+    try {
+      processPendingRow(sheet, row.rowNumber, row.applicationId);
+      processed++;
+    } catch (error) {
+      console.error('Failed to process ' + row.applicationId + ': ' + error.message);
+      markRowFailed(sheet, row.rowNumber, error.message);
+      alertEric(
+        'Background processing failed: ' + row.applicationId,
+        'App ID: ' + row.applicationId + '\n' +
+        'Row: ' + row.rowNumber + '\n' +
+        'Error: ' + error.message + '\n\n' +
+        'Stack:\n' + (error.stack || '(not available)')
+      );
+      failed++;
+    }
+  }
+
+  console.log('Background run complete: ' + processed + ' processed, ' + failed + ' failed');
+}
+
+// Atomic status flip inside a short script lock. Ensures two trigger runs can't
+// both grab the same row. Also stamps PROCESSING_STARTED so the sweeper can
+// distinguish "just claimed" from "genuinely stuck."
+function claimRow(sheet, rowNumber) {
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(CONFIG.CLAIM_LOCK_TIMEOUT_MS)) return false;
+  try {
+    const currentStatus = sheet.getRange(rowNumber, COL.STATUS).getValue();
+    if (currentStatus !== 'Pending Processing') return false;
+    sheet.getRange(rowNumber, COL.STATUS).setValue('Processing');
+    sheet.getRange(rowNumber, COL.PROCESSING_STARTED).setValue(new Date());
+    SpreadsheetApp.flush();
+    return true;
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function processPendingRow(sheet, rowNumber, applicationId) {
+  const pending = readPendingData(applicationId);
+  if (!pending) {
+    throw new Error('PendingData row not found for ' + applicationId);
+  }
+  const data = pending.data;
+
+  // 1. Check if a PDF already exists from a prior attempt (retry case).
+  //    If yes, reuse it. If the File ID is invalid (file deleted, etc.), regenerate.
+  const existingPdfUrl = sheet.getRange(rowNumber, COL.PDF_URL).getValue();
+  const existingPdfFileId = sheet.getRange(rowNumber, COL.PDF_FILE_ID).getValue();
+
+  let pdfFile;
+  if (existingPdfUrl && existingPdfFileId) {
+    try {
+      pdfFile = DriveApp.getFileById(existingPdfFileId);
+      console.log('Reusing existing PDF for ' + applicationId);
+    } catch (err) {
+      console.warn('Existing PDF File ID invalid, regenerating: ' + err.message);
+      pdfFile = createApplicationPDF(data, applicationId);
+    }
+  } else {
+    pdfFile = createApplicationPDF(data, applicationId);
+  }
+
+  // 2. Calculate distance (~1-3s)
+  const distance = calculateDistance(data);
+
+  // 3. Write PDF URL, PDF File ID, and Distance to the Master row IMMEDIATELY.
+  //    This must happen before the email send so an email failure doesn't
+  //    orphan the PDF in Drive with no link from the sheet.
+  sheet.getRange(rowNumber, COL.PDF_URL).setValue(pdfFile.getUrl());
+  sheet.getRange(rowNumber, COL.PDF_FILE_ID).setValue(pdfFile.getId());
+  sheet.getRange(rowNumber, COL.DISTANCE).setValue(distance);
+  SpreadsheetApp.flush();
+
+  // 4. Send applicant confirmation with retry. If this throws after all
+  //    retries, processBackgroundQueue will catch it and mark the row Failed,
+  //    but the PDF reference written above is preserved. retryFailedRow will
+  //    pick the row back up and the PDF will be reused, not regenerated.
+  sendApplicantConfirmationWithRetry(data, applicationId);
+
+  // 5. Email succeeded. Flip status to Submitted and clear PROCESSING_STARTED.
+  sheet.getRange(rowNumber, COL.STATUS).setValue('Submitted');
+  sheet.getRange(rowNumber, COL.PROCESSING_STARTED).setValue('');
+
+  // 6. Clean up PendingData (only after the row is fully Submitted so a
+  //    failed-and-retried row still has its source data).
+  deletePendingData(applicationId);
+
+  console.log('Successfully processed ' + applicationId);
+}
+
+function markRowFailed(sheet, rowNumber, errorMessage) {
+  const truncated = String(errorMessage).substring(0, 200);
+  sheet.getRange(rowNumber, COL.STATUS).setValue('Failed: ' + truncated);
+  sheet.getRange(rowNumber, COL.PROCESSING_STARTED).setValue('');
+}
+
+// === STUCK ROW SWEEPER ===
+// Trigger: every 15 minutes.
+// Any row in "Processing" whose PROCESSING_STARTED timestamp is older than
+// STUCK_ROW_MINUTES gets reset to "Pending Processing" and Eric gets one
+// rate-limited alert. This measures time-IN-Processing, not time-since-submission,
+// so a long queue backlog on surge day does not trigger false recoveries.
+function checkForStuckRows() {
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return;
+
+  const cutoff = new Date(Date.now() - CONFIG.STUCK_ROW_MINUTES * 60 * 1000);
+  const data = sheet.getRange(2, 1, lastRow - 1, COL.PROCESSING_STARTED).getValues();
+
+  let recovered = 0;
+  const stuckIds = [];
+
+  for (let i = 0; i < data.length; i++) {
+    const status = data[i][COL.STATUS - 1];
+    const processingStarted = data[i][COL.PROCESSING_STARTED - 1];
+    const appId = data[i][COL.APP_ID - 1];
+
+    if (status !== 'Processing') continue;
+
+    // Only recover if we have a valid PROCESSING_STARTED timestamp older than the cutoff.
+    // If the column is empty or non-Date for a Processing row, that's a manually-edited
+    // row or a pre-v3.0 legacy state. Skip it rather than guess - if truly stuck, it will
+    // be caught on a subsequent sweep after a human flips it back manually.
+    if (!(processingStarted instanceof Date)) continue;
+    if (processingStarted >= cutoff) continue;
+
+    sheet.getRange(i + 2, COL.STATUS).setValue('Pending Processing');
+    sheet.getRange(i + 2, COL.PROCESSING_STARTED).setValue('');
+    stuckIds.push(appId);
+    recovered++;
+  }
+
+  if (recovered > 0) {
+    console.warn('Recovered ' + recovered + ' stuck rows');
+    alertEric(
+      'Stuck rows recovered (' + recovered + ')',
+      recovered + ' row(s) were stuck in Processing for more than ' + CONFIG.STUCK_ROW_MINUTES + ' minutes ' +
+      'and have been reset to Pending Processing.\n\n' +
+      'Affected App IDs:\n' + stuckIds.join('\n') + '\n\n' +
+      'They will be retried on the next background queue run.'
+    );
+  }
+}
+
+// === DAILY DIGEST ===
+// Trigger: daily at 7am America/Los_Angeles.
+// Summarizes yesterday's Submitted applications to staff in a single email.
+// Replaces the old per-submission staff notification (which blew Gmail quota on surge days).
+function sendDailyDigest() {
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    console.log('Digest: sheet empty, skipping');
+    return;
+  }
+
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const allData = sheet.getRange(2, 1, lastRow - 1, COL.STATUS).getValues();
+
+  const submissions = [];
+  for (let i = 0; i < allData.length; i++) {
+    const row = allData[i];
+    const timestamp = row[COL.TIMESTAMP - 1];
+    const status = row[COL.STATUS - 1];
+
+    if (status !== 'Submitted') continue;
+    if (!(timestamp instanceof Date) || timestamp < cutoff) continue;
+
+    const income = Number(row[COL.HOUSEHOLD_INCOME - 1]) || 0;
+    const members = Number(row[COL.HOUSEHOLD_MEMBERS - 1]) || 1;
+
+    submissions.push({
+      applicationId: row[COL.APP_ID - 1],
+      timestamp: timestamp,
+      name: row[COL.STUDENT_NAME - 1],
+      email: row[COL.STUDENT_EMAIL - 1],
+      college: row[COL.COLLEGE - 1],
+      income: income,
+      members: members,
+      incomePerPerson: Math.round(income / (members || 1)),
+      pdfUrl: row[COL.PDF_URL - 1]
+    });
+  }
+
+  if (submissions.length === 0) {
+    console.log('Digest: no new submissions in last 24 hours, skipping send');
+    return;
+  }
+
+  submissions.sort(function(a, b) { return a.timestamp - b.timestamp; });
+
+  const dateStr = Utilities.formatDate(new Date(), CONFIG.DIGEST_TIMEZONE, 'EEEE, MMMM d, yyyy');
+  const subject = 'Campus Ready — Daily Applications Digest (' + submissions.length + ' new)';
+
+  let tableRows = '';
+  submissions.forEach(function(s) {
+    const timeStr = Utilities.formatDate(s.timestamp, CONFIG.DIGEST_TIMEZONE, 'MMM d, h:mm a');
+    tableRows += '<tr>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' + escapeHtml(s.name) + '</td>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' + escapeHtml(s.email) + '</td>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' + escapeHtml(s.college) + '</td>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;">$' + s.incomePerPerson.toLocaleString() + '</td>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;font-family:monospace;font-size:12px;">' + escapeHtml(s.applicationId) + '</td>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' + (s.pdfUrl ? '<a href="' + escapeHtml(s.pdfUrl) + '">PDF</a>' : '—') + '</td>' +
+      '<td style="padding:8px;border-bottom:1px solid #e5e7eb;color:#6b7280;font-size:12px;">' + timeStr + '</td>' +
+      '</tr>';
+  });
+
+  const sheetUrl = 'https://docs.google.com/spreadsheets/d/' + CONFIG.SPREADSHEET_ID;
+
+  const htmlBody =
+    '<div style="font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;max-width:900px;color:#374151;">' +
+    '<h2 style="color:#14b8a6;margin-bottom:4px;">Campus Ready — Daily Applications Digest</h2>' +
+    '<p style="color:#6b7280;margin-top:0;">' + dateStr + '</p>' +
+    '<p><strong>' + submissions.length + ' new application' + (submissions.length === 1 ? '' : 's') + '</strong> received in the last 24 hours.</p>' +
+    '<table style="border-collapse:collapse;width:100%;margin:20px 0;font-size:14px;">' +
+    '<thead><tr style="background:#f9fafb;text-align:left;">' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;">Student</th>' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;">Email</th>' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;">College</th>' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;text-align:right;">Income/Person</th>' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;">App ID</th>' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;">PDF</th>' +
+    '<th style="padding:8px;border-bottom:2px solid #e5e7eb;">Received</th>' +
+    '</tr></thead><tbody>' + tableRows + '</tbody></table>' +
+    '<p><a href="' + sheetUrl + '" style="color:#14b8a6;">Open Master sheet →</a></p>' +
+    '<hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">' +
+    '<p style="color:#6b7280;font-size:12px;">This is an automated digest. To stop receiving it, contact Eric.</p>' +
+    '</div>';
+
+  GmailApp.sendEmail(
+    CONFIG.STAFF_EMAILS.join(','),
+    subject,
+    submissions.length + ' new applications in the last 24 hours. Please view the HTML version.',
+    { htmlBody: htmlBody, name: 'Campus Ready Foundation' }
+  );
+
+  console.log('Digest sent: ' + submissions.length + ' submissions');
+}
+
+// === ERROR ALERTING ===
+// Rate-limited: max one email per unique subject hash per ALERT_RATE_LIMIT_MS.
+// Uses Script Properties to persist lastSent timestamps across trigger runs.
+function alertEric(subject, body) {
+  try {
+    const props = PropertiesService.getScriptProperties();
+    const digest = Utilities.computeDigest(Utilities.DigestAlgorithm.MD5, subject);
+    const sig = 'alert_' + Utilities.base64Encode(digest).substring(0, 16).replace(/[^A-Za-z0-9]/g, '');
+
+    const lastSentStr = props.getProperty(sig);
+    const now = Date.now();
+
+    if (lastSentStr) {
+      const lastSent = parseInt(lastSentStr);
+      if (now - lastSent < CONFIG.ALERT_RATE_LIMIT_MS) {
+        console.log('Alert rate-limited (within 1 hour): ' + subject);
+        return;
+      }
+    }
+
+    GmailApp.sendEmail(
+      CONFIG.ALERT_EMAIL,
+      '[CRF Alert] ' + subject,
+      body,
+      { name: 'Campus Ready Foundation — System Alert' }
+    );
+    props.setProperty(sig, String(now));
+    console.log('Alert sent: ' + subject);
+  } catch (err) {
+    console.error('alertEric failed: ' + err.message);
+  }
+}
+
+// === TRIGGER INSTALLATION ===
+// Run this ONCE from the editor after deploying v3.0.
+// Idempotent: clears old copies of its own triggers before creating new ones.
+function installTriggers() {
+  const managed = ['processBackgroundQueue', 'checkForStuckRows', 'sendDailyDigest'];
+  const existing = ScriptApp.getProjectTriggers();
+
+  existing.forEach(function(t) {
+    if (managed.indexOf(t.getHandlerFunction()) !== -1) {
+      ScriptApp.deleteTrigger(t);
+      console.log('Removed existing trigger for ' + t.getHandlerFunction());
+    }
+  });
+
+  ScriptApp.newTrigger('processBackgroundQueue').timeBased().everyMinutes(1).create();
+  console.log('Installed: processBackgroundQueue every 1 minute');
+
+  ScriptApp.newTrigger('checkForStuckRows').timeBased().everyMinutes(15).create();
+  console.log('Installed: checkForStuckRows every 15 minutes');
+
+  ScriptApp.newTrigger('sendDailyDigest')
+    .timeBased()
+    .atHour(CONFIG.DIGEST_HOUR)
+    .everyDays(1)
+    .inTimezone(CONFIG.DIGEST_TIMEZONE)
+    .create();
+  console.log('Installed: sendDailyDigest daily at ' + CONFIG.DIGEST_HOUR + ':00 ' + CONFIG.DIGEST_TIMEZONE);
+
+  return 'Triggers installed. Check the Triggers panel — you should see 3 time-driven triggers.';
+}
+
+// Helper to remove the three v3.0 triggers (rollback utility).
+// Symmetrical to installTriggers - only removes the managed set, never touches
+// other triggers that may exist in the project.
+function uninstallTriggers() {
+  const managed = ['processBackgroundQueue', 'checkForStuckRows', 'sendDailyDigest'];
+  const triggers = ScriptApp.getProjectTriggers();
+  let removed = 0;
+  triggers.forEach(function(t) {
+    if (managed.indexOf(t.getHandlerFunction()) !== -1) {
+      ScriptApp.deleteTrigger(t);
+      removed++;
+    }
+  });
+  return 'Removed ' + removed + ' v3.0 trigger(s). Other project triggers (if any) untouched.';
+}
+
+// === ADMIN HELPER: RETRY A FAILED ROW ===
+// Call from the script editor when a student emails in with a corrected address
+// or when you've fixed whatever caused a Failed row.
+// Usage: retryFailedRow('CR_1234567890_abcdef', 'correctedemail@example.com')
+//   - correctedEmail is optional. If provided, updates both the Master row AND
+//     the PendingData row before re-queuing.
+function retryFailedRow(applicationId, correctedEmail) {
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return 'Sheet empty';
+
+  const appIds = sheet.getRange(2, COL.APP_ID, lastRow - 1, 1).getValues();
+  let targetRow = -1;
+  for (let i = 0; i < appIds.length; i++) {
+    if (appIds[i][0] === applicationId) { targetRow = i + 2; break; }
+  }
+  if (targetRow === -1) return 'Application ID not found: ' + applicationId;
+
+  const status = sheet.getRange(targetRow, COL.STATUS).getValue();
+  if (String(status).indexOf('Failed') !== 0) {
+    return 'Row is not in Failed state (current status: ' + status + '). Refusing to re-queue.';
+  }
+
+  // Update email on both Master and PendingData if provided
+  if (correctedEmail) {
+    sheet.getRange(targetRow, COL.STUDENT_EMAIL).setValue(correctedEmail);
+    const pending = readPendingData(applicationId);
+    if (pending) {
+      pending.data.student_email = correctedEmail;
+      // Rewrite the PendingData row
+      const pdSheet = getPendingDataSheet();
+      pdSheet.getRange(pending.rowNumber, 2).setValue(JSON.stringify(pending.data));
+    } else {
+      return 'Warning: Master email updated but PendingData row not found for ' + applicationId +
+             '. Row cannot be re-queued (PDF generation needs full form data). Manual intervention required.';
+    }
+  }
+
+  // Flip status back so the next background run picks it up
+  sheet.getRange(targetRow, COL.STATUS).setValue('Pending Processing');
+  sheet.getRange(targetRow, COL.PROCESSING_STARTED).setValue('');
+
+  return 'Row ' + targetRow + ' (' + applicationId + ') re-queued. Background trigger will pick it up within 1 minute.';
+}
+
+// === ADMIN HELPER: RECALCULATE DISTANCE FOR ONE ROW ===
+// Re-runs distance calculation for a single row using the current logic.
+// Use this to fix rows whose Distance was written by the old address-based
+// version of calculateDistance and is now known to be wrong.
+//
+// Usage from the script editor:
+//   recalculateDistance('CR_1768584895995_mpoqr2')
+function recalculateDistance(applicationId) {
+  const COL_HOME_ZIP    = 17; // Q
+  const COL_COLLEGE_ZIP = 22; // V
+
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return 'Sheet empty';
+
+  const appIds = sheet.getRange(2, COL.APP_ID, lastRow - 1, 1).getValues();
+  let targetRow = -1;
+  for (let i = 0; i < appIds.length; i++) {
+    if (appIds[i][0] === applicationId) { targetRow = i + 2; break; }
+  }
+  if (targetRow === -1) return 'Application ID not found: ' + applicationId;
+
+  const homeZip    = sheet.getRange(targetRow, COL_HOME_ZIP).getValue();
+  const collegeZip = sheet.getRange(targetRow, COL_COLLEGE_ZIP).getValue();
+  const oldValue   = sheet.getRange(targetRow, COL.DISTANCE).getValue();
+
+  const newValue = calculateDistance({
+    student_zip: homeZip,
+    college_zip: collegeZip
+  });
+  sheet.getRange(targetRow, COL.DISTANCE).setValue(newValue);
+
+  return 'Row ' + targetRow + ' (' + applicationId + '): old=' + oldValue + '  →  new=' + newValue;
+}
+
+// === ADMIN HELPER: RECALCULATE DISTANCE FOR ALL SUBMITTED ROWS ===
+// One-shot bulk cleanup. Re-runs distance for every row whose Status is
+// "Submitted". Safe to re-run; idempotent. Logs the old/new value for every
+// row so you can audit the changes in the Apps Script execution log.
+function recalculateAllSubmittedDistances() {
+  const COL_HOME_ZIP    = 17; // Q (0-indexed in row array: 16)
+  const COL_COLLEGE_ZIP = 22; // V (0-indexed: 21)
+
+  const sheet = getMasterSheet();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return 'Sheet empty';
+
+  const data = sheet.getRange(2, 1, lastRow - 1, COL.DISTANCE).getValues();
+  let updated = 0, skipped = 0;
+
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i];
+    if (row[COL.STATUS - 1] !== 'Submitted') { skipped++; continue; }
+
+    const appId = row[COL.APP_ID - 1];
+    const oldVal = row[COL.DISTANCE - 1];
+    const newVal = calculateDistance({
+      student_zip: row[COL_HOME_ZIP - 1],
+      college_zip: row[COL_COLLEGE_ZIP - 1]
+    });
+    sheet.getRange(i + 2, COL.DISTANCE).setValue(newVal);
+    console.log(appId + ': ' + oldVal + ' → ' + newVal);
+    updated++;
+  }
+
+  return 'Done. Recalculated ' + updated + ' submitted rows, skipped ' + skipped + ' non-submitted rows. See log for per-row diff.';
+}
+
+// === FORM DATA PARSING ===
+function parseFormData(e) {
+  let data = {};
+
+  if (e.postData && e.postData.contents) {
+    const contents = e.postData.contents;
+    const pairs = contents.split('&');
+
+    for (const pair of pairs) {
+      const [key, value] = pair.split('=');
+      if (key && value !== undefined) {
+        const decodedKey = decodeURIComponent(key);
+        const decodedValue = decodeURIComponent(value.replace(/\+/g, ' '));
+
+        // Handle multi-value form fields (checkbox groups)
+        if (data[decodedKey] !== undefined) {
+          if (Array.isArray(data[decodedKey])) {
+            data[decodedKey].push(decodedValue);
+          } else {
+            data[decodedKey] = [data[decodedKey], decodedValue];
+          }
+        } else {
+          data[decodedKey] = decodedValue;
+        }
+      }
+    }
+  } else if (e.parameter) {
+    data = Object.assign({}, e.parameter);
+  } else if (e.postData && e.postData.type === 'application/json') {
+    data = JSON.parse(e.postData.contents || '{}');
+  } else {
+    throw new Error('No form data received');
+  }
+
+  if (data._honeypot) throw new Error('Spam detected');
+  return data;
+}
+
+// === DISTANCE CALCULATION ===
+// Geocodes from ZIP codes only (not full address strings) to avoid the
+// typo-induced mis-geocoding seen in the 2026 cohort, where five short
+// Bay Area trips returned as 800-940 mile routes because Google's geocoder
+// picked similarly-named places in other states.
+//
+// Calls two Google Maps APIs:
+//   1. Distance Matrix - driving distance ZIP-to-ZIP
+//   2. Geocoding       - lat/lng of each ZIP for the sanity-check denominator
+//
+// If driving distance is more than 2.5x the straight-line distance between
+// the two ZIP centroids, the result is flagged for human review rather than
+// written as a (possibly bogus) number. 2.5x accounts for California's
+// mountain and water routing while still catching the 10-17x errors seen
+// in the 2026 cohort.
+function calculateDistance(data) {
+  const homeZip    = _normalizeZip(data.student_zip);
+  const collegeZip = _normalizeZip(data.college_zip);
+
+  if (!/^\d{5}$/.test(homeZip))    return 'Invalid home ZIP: ' + (homeZip || '(empty)');
+  if (!/^\d{5}$/.test(collegeZip)) return 'Invalid college ZIP: ' + (collegeZip || '(empty)');
+
+  try {
+    // --- Driving distance via Distance Matrix API ---
+    const dmUrl = 'https://maps.googleapis.com/maps/api/distancematrix/json?' +
+      'origins='      + encodeURIComponent(homeZip    + ', USA') +
+      '&destinations='+ encodeURIComponent(collegeZip + ', USA') +
+      '&units=imperial' +
+      '&key=' + CONFIG.GOOGLE_MAPS_API_KEY;
+
+    const dmResp = UrlFetchApp.fetch(dmUrl, { method: 'GET', muteHttpExceptions: true });
+    if (dmResp.getResponseCode() !== 200) return 'API Error - will retry later';
+
+    const dmData = JSON.parse(dmResp.getContentText());
+    if (dmData.status !== 'OK' || !dmData.rows || !dmData.rows[0] ||
+        !dmData.rows[0].elements || !dmData.rows[0].elements[0]) {
+      return 'Route not found';
+    }
+    const element = dmData.rows[0].elements[0];
+    if (element.status !== 'OK' || !element.distance) return 'Distance unavailable';
+
+    // Use raw meters from the API (always correct, regardless of text formatting).
+    // Old code parsed element.distance.text, which silently broke decimals like "1.5 mi".
+    const drivingMiles = Math.round(element.distance.value / 1609.34);
+
+    // --- Sanity check via Geocoding API ---
+    const homeLatLng    = _geocodeZipToLatLng(homeZip);
+    const collegeLatLng = _geocodeZipToLatLng(collegeZip);
+
+    // If geocoding fails for either ZIP, accept the driving distance unchecked
+    // and log the limitation. Better to record a likely-correct value than
+    // refuse one because the secondary check couldn't run.
+    if (!homeLatLng || !collegeLatLng) {
+      console.warn('Sanity check skipped: geocoding failed for ZIPs ' +
+        homeZip + ' / ' + collegeZip + '. Returning driving distance unchecked.');
+      return drivingMiles;
+    }
+
+    const straightMiles = _haversineMiles(
+      homeLatLng.lat, homeLatLng.lng,
+      collegeLatLng.lat, collegeLatLng.lng
+    );
+
+    if (straightMiles > 1 && drivingMiles > straightMiles * 2.5) {
+      return 'Needs Review: driving ' + drivingMiles +
+        ' mi vs straight-line ' + Math.round(straightMiles) +
+        ' mi (ratio ' + (drivingMiles / straightMiles).toFixed(1) + 'x)';
+    }
+
+    return drivingMiles;
+  } catch (err) {
+    console.error('Distance calculation error: ' + err.message);
+    return 'Error - will retry later';
+  }
+}
+
+// Returns {lat, lng} for a 5-digit US ZIP, or null on failure.
+function _geocodeZipToLatLng(zip) {
+  try {
+    const url = 'https://maps.googleapis.com/maps/api/geocode/json?' +
+      'address=' + encodeURIComponent(zip + ', USA') +
+      '&key=' + CONFIG.GOOGLE_MAPS_API_KEY;
+    const resp = UrlFetchApp.fetch(url, { method: 'GET', muteHttpExceptions: true });
+    if (resp.getResponseCode() !== 200) return null;
+    const data = JSON.parse(resp.getContentText());
+    if (data.status !== 'OK' || !data.results || !data.results[0]) return null;
+    const loc = data.results[0].geometry && data.results[0].geometry.location;
+    if (!loc || typeof loc.lat !== 'number' || typeof loc.lng !== 'number') return null;
+    return { lat: loc.lat, lng: loc.lng };
+  } catch (err) {
+    console.warn('Geocode failed for ZIP ' + zip + ': ' + err.message);
+    return null;
+  }
+}
+
+// Great-circle distance between two lat/lng points, in miles.
+function _haversineMiles(lat1, lng1, lat2, lng2) {
+  const R = 3958.8; // Earth radius in miles
+  const toRad = function(deg) { return deg * Math.PI / 180; };
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+            Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// Normalizes a ZIP code value, padding leading zeros if Google Sheets stripped
+// them. Sheets stores numeric-looking strings (like "02302") as numbers, which
+// drops the leading zero. This fixes that for MA, CT, NJ, PR, and any other
+// area whose ZIPs start with 0.
+function _normalizeZip(raw) {
+  let zip = String(raw || '').trim().substring(0, 5);
+  if (/^\d{1,4}$/.test(zip)) zip = zip.padStart(5, '0');
+  return zip;
+}
+
+// === PDF GENERATION ===
+function createApplicationPDF(data, applicationId) {
+  const htmlContent = buildPDFHTML(data, applicationId);
+  const htmlBlob = Utilities.newBlob(htmlContent, 'text/html', 'temp.html');
+  const pdfBlob = htmlBlob.getAs('application/pdf');
+
+  const filename = buildPdfFilename(data.student_name);
+  pdfBlob.setName(filename);
+
+  const folder = DriveApp.getFolderById(CONFIG.PDF_FOLDER_ID);
+  return folder.createFile(pdfBlob);
+}
+
+// Builds a filename in the format "LastName_FirstName.pdf" so PDFs sort
+// alphabetically by last name in Drive and are easy to search by name.
+function buildPdfFilename(studentName) {
+  const raw = String(studentName || 'Unnamed_Applicant').trim();
+  const cleaned = raw
+    .replace(/[\/\\:*?"<>|]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const parts = cleaned.split(' ');
+  if (parts.length === 1) return parts[0] + '.pdf';
+
+  const last = parts[parts.length - 1];
+  const rest = parts.slice(0, parts.length - 1).join('_');
+  return last + '_' + rest + '.pdf';
+}
+
+// === REPLACEMENT FUNCTION: buildPDFHTML (final) ===
+// Drop-in replacement for buildPDFHTML() in Application_Main_Script.gs.
+// Paste this entire function, replacing the old one. Nothing else changes.
+//
+// Typography:
+//   Playfair Display 700 — org name, document title, section headers (loaded via Google Fonts)
+//   Arial — all field labels, values, and body text (server-safe fallback if Playfair fails)
+//
+// What's new vs the original:
+//   - Branded header with logo (fetched from Drive, embedded as base64)
+//   - Playfair Display via Google Fonts @import
+//   - All fields now present: pg_name, pg_phone, pg_email, accompany, gender, student_income
+//   - Income per person computed and shown
+//   - Raw form keys mapped to human-readable labels (including the "applicances" typo)
+//   - Font sizes calibrated for Apps Script's HTML-to-PDF renderer (~1.25x inflation)
+//   - Explicit 33% column widths prevent label wrapping
+//   - Footer uses a two-cell table (flexbox not reliable in this renderer)
+
+// === REPLACEMENT FUNCTION: buildPDFHTML (final) ===
+// Drop-in replacement for buildPDFHTML() in Application_Main_Script.gs.
+// Paste this entire function, replacing the old one. Nothing else changes.
+//
+// Typography:
+//   Playfair Display 700 — org name, document title, section headers (loaded via Google Fonts)
+//   Arial — all field labels, values, and body text (server-safe fallback if Playfair fails)
+//
+// What's new vs the original:
+//   - Branded header with logo (fetched from Drive, embedded as base64)
+//   - Playfair Display via Google Fonts @import
+//   - All fields now present: pg_name, pg_phone, pg_email, accompany, gender, student_income
+//   - Income per person computed and shown
+//   - Raw form keys mapped to human-readable labels (including the "applicances" typo)
+//   - Font sizes calibrated for Apps Script's HTML-to-PDF renderer (~1.25x inflation)
+//   - Explicit 33% column widths prevent label wrapping
+//   - Footer uses a two-cell table (flexbox not reliable in this renderer)
+
+function buildPDFHTML(data, applicationId) {
+
+  // === LOGO ===
+  // The logo PNG is stored in the CRF Drive folder referenced by PDF_FOLDER_ID.
+  // We fetch it by file ID and embed as base64 so no external URL dependency.
+  // Falls back to text-only org name if the fetch fails for any reason.
+  //
+  // TO SET UP: find the logo file in Drive, copy its file ID, paste below.
+  var LOGO_FILE_ID = '1LHq8wqjMIdvDp5cNYW5ZwppY1WiGYZjD';
+
+  var logoHtml = '';
+  if (LOGO_FILE_ID) {
+    try {
+      var logoFile = DriveApp.getFileById(LOGO_FILE_ID);
+      var blob     = logoFile.getBlob();
+      var b64      = Utilities.base64Encode(blob.getBytes());
+      var mime     = blob.getContentType() || 'image/png';
+      logoHtml = '<img src="data:' + mime + ';base64,' + b64 + '" ' +
+                 'style="height:48px;width:auto;display:block;" ' +
+                 'alt="Campus Ready Foundation">';
+    } catch (e) {
+      console.warn('Logo fetch failed: ' + e.message);
+    }
+  }
+
+  // === LABEL MAPS ===
+  // Maps raw form submission values to display strings.
+  // "applicances" is an intentional match for the misspelled form field value.
+  var CIRCUMSTANCE_LABELS = {
+    'SNAP/WIC/free_meals':      'Receives SNAP, WIC, or free/reduced school meals',
+    'housing_instability':      'Housing instability or transitional housing',
+    'no_internet_computer':     'No internet or computer access at home',
+    'unemployed_underemployed': 'Parent(s)/guardian(s) unemployed or underemployed',
+    'financial_contributor':    'Contributes financially to the household'
+  };
+
+  var CONCERN_LABELS = {
+    'dorm_supplies':  'Dorm supplies',
+    'applicances':    'Appliances',
+    'hygiene_items':  'Hygiene items',
+    'transportation': 'Transportation',
+    'meals_food':     'Meals and food'
+  };
+
+  // === HELPERS ===
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g,  '&amp;')
+      .replace(/</g,  '&lt;')
+      .replace(/>/g,  '&gt;')
+      .replace(/"/g,  '&quot;');
+  }
+
+  function formatDate(raw) {
+    if (!raw) return '';
+    var d = new Date(raw);
+    if (isNaN(d.getTime())) return esc(String(raw));
+    return d.toLocaleDateString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric'
+    });
+  }
+
+  function formatCurrency(val) {
+    var n = parseFloat(String(val || '').replace(/[$,\s]/g, ''));
+    if (isNaN(n)) return '';
+    return '$' + Math.round(n).toLocaleString('en-US');
+  }
+
+  function formatNumber(val) {
+    var n = parseFloat(val);
+    if (isNaN(n)) return '';
+    return Math.round(n).toLocaleString('en-US');
+  }
+
+  function incomePerPerson(income, members) {
+    var inc = parseFloat(String(income || '').replace(/[$,\s]/g, ''));
+    var mem = parseInt(members);
+    if (isNaN(inc) || isNaN(mem) || mem < 1) return '';
+    return '$' + Math.round(inc / mem).toLocaleString('en-US');
+  }
+
+  function mapList(raw, labelMap) {
+    var items = Array.isArray(raw) ? raw : (raw ? [String(raw)] : []);
+    return items
+      .map(function(k) { return labelMap[k] || esc(k); })
+      .filter(Boolean);
+  }
+
+  // === COMPONENT BUILDERS ===
+
+  // Single data field — label above value.
+  // opts.colspan: number of columns to span (default 1 of 3)
+  // opts.accent:  render value in teal (used for Yes/positive answers)
+  // opts.raw:     pre-rendered HTML for the value cell (tags, multi-line, etc.)
+  function field(label, value, opts) {
+    opts = opts || {};
+    var span      = opts.colspan || 1;
+    var colAttr   = span > 1 ? ' colspan="' + span + '"' : '';
+    var pct       = (span * 33) + '%';
+    var empty     = (!value || value === '');
+    var color     = (opts.accent && !empty) ? '#0F6E56' : '#1a1a1a';
+    var valStyle  = empty
+      ? 'font-size:8pt;font-family:Arial,sans-serif;font-weight:400;color:#9CA3AF;font-style:italic;margin-top:2px;line-height:1.35;'
+      : 'font-size:8pt;font-family:Arial,sans-serif;font-weight:700;color:' + color + ';margin-top:2px;line-height:1.35;';
+    var display   = empty ? 'Not provided' : (opts.raw ? opts.raw : esc(String(value)));
+
+    return '<td' + colAttr + ' style="width:' + pct + ';' +
+           'padding:5px 24px 6px 0;border-bottom:0.5px solid #E5E7EB;vertical-align:top;">' +
+      '<div style="font-size:6.5pt;font-family:Arial,sans-serif;font-weight:400;' +
+           'text-transform:uppercase;letter-spacing:0.07em;color:#6B7280;">' +
+           esc(label) + '</div>' +
+      '<div style="' + valStyle + '">' + display + '</div>' +
+    '</td>';
+  }
+
+  // Full-width field spanning all three columns — used for addresses and multi-line values.
+  function fieldFull(label, value, opts) {
+    opts = opts || {};
+    var empty    = (!value || value === '');
+    var valStyle = empty
+      ? 'font-size:8pt;font-family:Arial,sans-serif;font-weight:400;color:#9CA3AF;font-style:italic;margin-top:2px;'
+      : 'font-size:8pt;font-family:Arial,sans-serif;font-weight:700;color:#1a1a1a;margin-top:2px;';
+    var display  = empty ? 'Not provided' : (opts.raw ? opts.raw : esc(String(value)));
+
+    return '<tr><td colspan="3" style="padding:5px 0 6px 0;border-bottom:0.5px solid #E5E7EB;">' +
+      '<div style="font-size:6.5pt;font-family:Arial,sans-serif;font-weight:400;' +
+           'text-transform:uppercase;letter-spacing:0.07em;color:#6B7280;">' +
+           esc(label) + '</div>' +
+      '<div style="' + valStyle + '">' + display + '</div>' +
+    '</td></tr>';
+  }
+
+  // Section divider — Playfair Display, teal, with teal underline rule.
+  function sectionHeader(title) {
+    return '<tr><td colspan="3" style="padding:14px 0 5px 0;">' +
+      '<div style="font-size:8.5pt;font-family:\'Playfair Display\',Georgia,serif;font-weight:700;' +
+           'text-transform:uppercase;letter-spacing:0.09em;color:#469E92;' +
+           'padding-bottom:4px;border-bottom:1px solid #469E92;">' +
+           esc(title) + '</div>' +
+    '</td></tr>';
+  }
+
+  // Essay block with teal left border.
+  function essayBlock(question, text, wordCount) {
+    var wcHtml = wordCount
+      ? '<div style="font-size:6.5pt;font-family:Arial,sans-serif;' +
+        'color:#9CA3AF;text-align:right;margin-top:4px;">' + wordCount + ' words</div>'
+      : '';
+    return '<tr><td colspan="3" style="padding:5px 0 8px 0;">' +
+      '<div style="border-left:2.5px solid #469E92;padding:8px 11px;background:#F9FAFB;">' +
+        '<div style="font-size:6.5pt;font-family:Arial,sans-serif;font-weight:700;' +
+             'text-transform:uppercase;letter-spacing:0.07em;color:#469E92;margin-bottom:5px;">' +
+             esc(question) + '</div>' +
+        '<div style="font-size:8pt;font-family:Arial,sans-serif;font-weight:400;' +
+             'color:#374151;line-height:1.6;white-space:pre-wrap;">' +
+             esc(text || 'No response provided') + '</div>' +
+        wcHtml +
+      '</div>' +
+    '</td></tr>';
+  }
+
+  // Pill tag for affordability concerns.
+  function tag(label) {
+    return '<span style="display:inline-block;font-size:7pt;font-family:Arial,sans-serif;' +
+           'font-weight:700;background:#EAF4F3;color:#0F6E56;border-radius:3px;' +
+           'padding:2px 6px;margin:2px 3px 0 0;">' + esc(label) + '</span>';
+  }
+
+  // === DATA ASSEMBLY ===
+
+  var submissionDate = formatDate(new Date());
+
+  // Student
+  var studentName   = data.student_name   || '';
+  var studentEmail  = data.student_email  || '';
+  var studentPhone  = data.student_phone  || '';
+  var studentDob    = formatDate(data.student_dob);
+  var gender        = data.gender         || '';
+  var studentIncome = formatCurrency(data.student_income);
+  var homeAddress   = [
+    data.student_address,
+    data.student_city_name,
+    data.student_state,
+    data.student_zip
+  ].filter(Boolean).join(', ');
+
+  // Parent / Guardian
+  var pgName    = data.pg_name   || '';
+  var pgPhone   = data.pg_phone  || '';
+  var pgEmail   = data.pg_email  || '';
+  var accompany = data.accompany || '';
+
+  // College
+  var college     = data.college || '';
+  var startDate   = formatDate(data.start_date);
+  var collegeAddr = [
+    data.college_address,
+    data.college_city_name,
+    data.college_state,
+    data.college_zip
+  ].filter(Boolean).join(', ');
+
+  // Financial
+  var hhIncome  = formatCurrency(data.household_income);
+  var hhMembers = data.household_members ? String(data.household_members) : '';
+  var ipp       = incomePerPerson(data.household_income, data.household_members);
+  var fafsa     = data.fafsa || '';
+  var sai       = (data.sai !== undefined && data.sai !== '') ? formatNumber(data.sai) : '';
+
+  // Circumstances — one line each
+  var circumItems = mapList(data.household_circumstances, CIRCUMSTANCE_LABELS);
+  var circumHtml  = circumItems.length
+    ? circumItems.map(function(l) {
+        return '<div style="font-size:8pt;font-family:Arial,sans-serif;' +
+               'font-weight:700;color:#1a1a1a;padding:1px 0;">' + esc(l) + '</div>';
+      }).join('')
+    : '<span style="font-size:8pt;font-family:Arial,sans-serif;' +
+      'font-weight:400;color:#9CA3AF;font-style:italic;">None selected</span>';
+
+  // Concerns — pill tags
+  var concernItems = mapList(data.affordability_concerns, CONCERN_LABELS);
+  if (data.other_concern_text) {
+    concernItems.push('Other: ' + data.other_concern_text);
+  }
+  var concernHtml = concernItems.length
+    ? concernItems.map(tag).join('')
+    : '<span style="font-size:8pt;font-family:Arial,sans-serif;' +
+      'font-weight:400;color:#9CA3AF;font-style:italic;">None selected</span>';
+
+  // Essays — countWords() is the existing helper already in the script
+  var essay1   = data.essay1 || '';
+  var essay2   = data.essay2 || '';
+  var essay2Wc = countWords(essay2);
+
+  // === HTML OUTPUT ===
+  return '<!DOCTYPE html>\n' +
+  '<html><head><meta charset="UTF-8">\n' +
+  '<style>\n' +
+  '@import url(\'https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap\');\n' +
+  'body{font-family:Arial,sans-serif;margin:32px 40px 28px;color:#1a1a1a;}\n' +
+  'table{border-collapse:collapse;width:100%;}\n' +
+  'td{vertical-align:top;}\n' +
+  '</style>\n' +
+  '</head><body>\n' +
+
+  // ── HEADER ────────────────────────────────────────────────────────
+  // Two-cell table: logo + identity left, app ID + date right.
+  '<table style="width:100%;margin-bottom:0;">' +
+  '<tr>' +
+    '<td style="vertical-align:bottom;padding-bottom:8px;">' +
+      (logoHtml || '') +
+      // If no logo, show org name in Playfair as fallback
+      (!logoHtml
+        ? '<div style="font-size:12pt;font-family:\'Playfair Display\',Georgia,serif;' +
+          'font-weight:700;color:#1a1a1a;letter-spacing:0.02em;">Campus Ready Foundation</div>'
+        : '') +
+      '<div style="font-size:13pt;font-family:\'Playfair Display\',Georgia,serif;' +
+           'font-weight:700;color:#1a1a1a;margin-top:6px;">Grant Application</div>' +
+    '</td>' +
+    '<td style="text-align:right;vertical-align:top;padding-bottom:8px;">' +
+      '<div style="font-size:7.5pt;font-family:\'Courier New\',monospace;color:#6B7280;">' +
+           esc(applicationId) + '</div>' +
+      '<div style="font-size:7.5pt;font-family:Arial,sans-serif;color:#6B7280;margin-top:2px;">' +
+           'Submitted ' + submissionDate + '</div>' +
+    '</td>' +
+  '</tr>' +
+  '</table>' +
+  '<hr style="border:none;border-top:2.5px solid #469E92;margin:0 0 14px;">' +
+
+  // ── CONTENT TABLE ─────────────────────────────────────────────────
+  '<table>' +
+
+  // Student
+  sectionHeader('Student') +
+  '<tr>' +
+    field('Full name',         studentName) +
+    field('Date of birth',     studentDob) +
+    field('Gender',            gender) +
+  '</tr>' +
+  '<tr>' +
+    field('Email',             studentEmail) +
+    field('Phone',             studentPhone) +
+    field('Individual income', studentIncome) +
+  '</tr>' +
+  fieldFull('Home address', homeAddress) +
+
+  // Parent / Guardian
+  sectionHeader('Parent / Guardian') +
+  '<tr>' +
+    field('Name(s)',                pgName,    { colspan: 2 }) +
+    field('Accompanying to campus', accompany, { accent: accompany === 'Yes' }) +
+  '</tr>' +
+  '<tr>' +
+    field('Phone', pgPhone) +
+    field('Email', pgEmail, { colspan: 2 }) +
+  '</tr>' +
+
+  // College
+  sectionHeader('College') +
+  '<tr>' +
+    field('Institution',    college) +
+    field('Expected start', startDate) +
+    field('College Location', collegeAddr) +
+  '</tr>' +
+
+  // Financial
+  sectionHeader('Financial') +
+  '<tr>' +
+    field('Household income',  hhIncome) +
+    field('Household members', hhMembers) +
+    field('Income per person', ipp) +
+  '</tr>' +
+  '<tr>' +
+    field('Aid application',   fafsa) +
+    field('Student Aid Index', sai, { colspan: 2 }) +
+  '</tr>' +
+  '<tr>' +
+    '<td colspan="3" style="padding:5px 0 6px 0;border-bottom:0.5px solid #E5E7EB;">' +
+      '<div style="font-size:6.5pt;font-family:Arial,sans-serif;font-weight:400;' +
+           'text-transform:uppercase;letter-spacing:0.07em;color:#6B7280;">' +
+           'Household circumstances</div>' +
+      '<div style="margin-top:3px;">' + circumHtml + '</div>' +
+    '</td>' +
+  '</tr>' +
+  '<tr>' +
+    '<td colspan="3" style="padding:5px 0 8px 0;">' +
+      '<div style="font-size:6.5pt;font-family:Arial,sans-serif;font-weight:400;' +
+           'text-transform:uppercase;letter-spacing:0.07em;color:#6B7280;">' +
+           'Affordability concerns</div>' +
+      '<div style="margin-top:4px;">' + concernHtml + '</div>' +
+    '</td>' +
+  '</tr>' +
+
+  // Essays
+  sectionHeader('Essays') +
+  essayBlock('Essay 1 — Why is this award meaningful to you?', essay1, null) +
+  essayBlock('Essay 2 — Describe a challenge', essay2, essay2Wc) +
+
+  '</table>' +
+
+  // ── FOOTER ────────────────────────────────────────────────────────
+  // Two-cell table: tagline + URL left, app ID right.
+  '<table style="width:100%;margin-top:14px;border-top:0.5px solid #E5E7EB;">' +
+  '<tr>' +
+    '<td style="padding-top:7px;">' +
+      '<span style="font-size:7pt;font-family:Arial,sans-serif;' +
+            'color:#9CA3AF;font-style:italic;">' +
+            'Campus Ready Foundation &middot; campusready.org &middot; Submitted ' +
+            submissionDate + '</span>' +
+    '</td>' +
+    '<td style="text-align:right;padding-top:7px;">' +
+      '<span style="font-size:7pt;font-family:\'Courier New\',monospace;color:#9CA3AF;">' +
+            esc(applicationId) + '</span>' +
+    '</td>' +
+  '</tr>' +
+  '</table>' +
+
+  '</body></html>';
+}
+
+// === APPLICANT CONFIRMATION EMAIL (unchanged template, called from background) ===
+function sendApplicantConfirmationWithRetry(data, applicationId) {
+  let lastError;
+  for (let attempt = 1; attempt <= CONFIG.EMAIL_RETRY_ATTEMPTS; attempt++) {
+    try {
+      sendApplicantConfirmation(data, applicationId);
+      return;
+    } catch (err) {
+      lastError = err;
+      console.warn('Confirmation email attempt ' + attempt + ' failed: ' + err.message);
+      if (attempt < CONFIG.EMAIL_RETRY_ATTEMPTS) {
+        Utilities.sleep(Math.pow(2, attempt) * 1000);  // 2s, 4s
+      }
+    }
+  }
+  throw new Error('Confirmation email failed after ' + CONFIG.EMAIL_RETRY_ATTEMPTS + ' attempts: ' + lastError.message);
+}
+
+function sendApplicantConfirmation(data, applicationId) {
+  if (!data.student_email) return;
+
+  const firstName = data.student_name ? data.student_name.split(' ')[0] : 'Future Leader';
+  const subject = 'Your Campus Ready Application is Confirmed!';
+
+  const textBody =
+'Dear ' + firstName + ',\n\n' +
+'Congratulations on taking this important step toward your college journey!\n\n' +
+'We\'ve successfully received your Campus Ready Foundation grant application, and we\'re genuinely excited to learn more about your story and aspirations.\n\n' +
+'YOUR APPLICATION DETAILS\n' +
+'━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+'Application ID: ' + applicationId + '\n' +
+'Submitted: ' + new Date().toLocaleDateString('en-US', { year:'numeric', month:'long', day:'numeric', hour:'2-digit', minute:'2-digit' }) + '\n' +
+'College: ' + (data.college || 'Not specified') + '\n\n' +
+'WHAT\'S NEXT?\n' +
+'━━━━━━━━━━━━━\n' +
+'✓ This confirmation email (check your spam folder if needed)\n' +
+'• Our board will thoughtfully review all applications after May 15\n' +
+'• Decision notifications will be sent by June 1\n' +
+'• If selected, we\'ll reach out about your Campus Ready Essentials Kit and ongoing support\n\n' +
+'We know how challenging the college application and funding process can be. You\'ve already shown incredible determination by applying for this grant, and we want you to know that regardless of the outcome, we\'re rooting for your success.\n\n' +
+'Questions? We\'re here to help at apply@campusready.org\n\n' +
+'Respectfully,\n' +
+'The Campus Ready Foundation Team\n\n' +
+'P.S. Save this email and your Application ID (' + applicationId + ') for your records!';
+
+  const htmlBody = buildConfirmationHTML(firstName, applicationId, data);
+
+  GmailApp.sendEmail(
+    data.student_email,
+    subject,
+    textBody,
+    { htmlBody: htmlBody, name: 'Campus Ready Foundation', replyTo: 'apply@campusready.org' }
+  );
+  console.log('Applicant confirmation sent to ' + data.student_email);
+}
+
+function buildConfirmationHTML(firstName, applicationId, data) {
+  const submittedDate = new Date().toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  });
+  return '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><style>' +
+'body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; margin: 0; padding: 20px; background-color: #f9fafb; line-height: 1.6; color: #374151; }' +
+'.container { max-width: 600px; margin: 0 auto; background: white; border-radius: 16px; overflow: hidden; box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1); }' +
+'.header { background: linear-gradient(135deg, #14b8a6 0%, #0891b2 100%); color: white; padding: 48px; text-align: center; }' +
+'.success-icon { width: 80px; height: 80px; background: rgba(255,255,255,0.2); border-radius: 50%; display: block; text-align: center; line-height: 80px; margin: 0 auto 24px; border: 2px solid rgba(255,255,255,0.3); }'+
+  '.checkmark { color: white; font-size: 40px; font-weight: bold; line-height: 80px; }' +
+'.header h1 { margin: 0 0 8px; font-size: 32px; font-weight: 700; }' +
+'.header p { margin: 0; font-size: 18px; opacity: 0.9; }' +
+'.content { padding: 48px; }' +
+'.greeting { font-size: 24px; color: #1f2937; margin-bottom: 24px; font-weight: 600; }' +
+'.intro-text { font-size: 18px; line-height: 1.6; margin-bottom: 32px; }' +
+'.details-box { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 12px; padding: 32px; margin: 32px 0; }' +
+'.details-box h3 { margin: 0 0 20px; color: #14b8a6; font-size: 18px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }' +
+'.detail-row { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; border-bottom: 1px solid #e5e7eb; }' +
+'.detail-row:last-child { border-bottom: none; }' +
+'.detail-label { font-weight: 600; color: #374151; }' +
+'.detail-value { color: #6b7280; font-family: Monaco, monospace; font-size: 14px; }' +
+'.next-steps { background: #f0fdfa; border: 2px solid #99f6e4; border-radius: 12px; padding: 32px; margin: 32px 0; }' +
+'.next-steps h3 { color: #14b8a6; margin: 0 0 20px; font-size: 20px; font-weight: 700; }' +
+'.step-item { margin-bottom: 16px; padding-left: 32px; position: relative; }' +
+'.step-item:before { content: "•"; position: absolute; left: 0; top: 0; color: #14b8a6; font-size: 24px; font-weight: bold; line-height: 1; }' +
+'.step-title { font-weight: 600; color: #0f766e; margin-bottom: 4px; }' +
+'.step-desc { color: #374151; line-height: 1.5; }' +
+'.encouragement { background: #ecfdf5; border: 2px solid #86efac; border-radius: 12px; padding: 32px; margin: 32px 0; text-align: center; }' +
+'.encouragement p { margin: 0; color: #065f46; font-style: italic; font-size: 18px; line-height: 1.6; }' +
+'.closing-text { font-size: 16px; line-height: 1.6; margin: 32px 0; }' +
+'.signature { margin-top: 40px; padding-top: 32px; border-top: 2px solid #e5e7eb; }' +
+'.signature-line { color: #374151; font-weight: 600; margin-bottom: 4px; font-size: 16px; }' +
+'.signature-title { color: #6b7280; font-size: 14px; }' +
+'.footer { background: #f9fafb; padding: 32px; text-align: center; border-top: 1px solid #e5e7eb; }' +
+'.footer h4 { margin: 0 0 8px; color: #374151; font-size: 16px; font-weight: 600; }' +
+'.footer p { margin: 0 0 16px; color: #6b7280; font-size: 14px; }' +
+'.contact-link { color: #14b8a6; text-decoration: none; font-weight: 600; }' +
+'.important-note { background: #fef3c7; border: 2px solid #f59e0b; border-radius: 8px; padding: 16px; margin-top: 16px; }' +
+'.important-note strong { color: #92400e; }' +
+'@media (max-width: 640px) { .container { margin: 10px; border-radius: 12px; } .header, .content { padding: 32px 24px; } .details-box, .next-steps, .encouragement { padding: 24px; } .header h1 { font-size: 24px; } .greeting { font-size: 20px; } .detail-row { flex-direction: column; align-items: flex-start; gap: 4px; } }' +
+'</style></head><body>' +
+'<div class="container">' +
+'<div class="header"><div class="success-icon"><div class="checkmark">✓</div></div>' +
+'<h1>Application Confirmed!</h1><p>Your journey to college success starts here</p></div>' +
+'<div class="content">' +
+'<div class="greeting">Dear ' + firstName + ',</div>' +
+'<p class="intro-text">Congratulations on taking this important step toward your college journey! We\'ve successfully received your Campus Ready Foundation grant application, and we\'re genuinely excited to learn more about your story and aspirations.</p>' +
+'<div class="details-box"><h3>Your Application Details</h3>' +
+'<div class="detail-row"><span class="detail-label">Application ID:</span><span class="detail-value">' + applicationId + '</span></div>' +
+'<div class="detail-row"><span class="detail-label">Submitted:</span><span class="detail-value">' + submittedDate + '</span></div>' +
+'<div class="detail-row"><span class="detail-label">College:</span><span class="detail-value">' + (data.college || 'Not specified') + '</span></div>' +
+'</div>' +
+'<div class="next-steps"><h3>What Happens Next</h3>' +
+'<div class="step-item"><div class="step-title">Email Confirmation</div><div class="step-desc">You\'re reading it right now! Save this for your records.</div></div>' +
+'<div class="step-item"><div class="step-title">Application Review</div><div class="step-desc">Our board will thoughtfully review all applications after the May 15 deadline</div></div>' +
+'<div class="step-item"><div class="step-title">Decision Notification</div><div class="step-desc">All applicants will be notified of decisions by <strong>June 1</strong></div></div>' +
+'<div class="step-item"><div class="step-title">If Selected</div><div class="step-desc">We\'ll contact you about your Campus Ready Essentials Kit and ongoing support</div></div>' +
+'</div>' +
+'<div class="encouragement"><p>We know how challenging the college application and funding process can be. You\'ve already shown incredible determination by applying for this grant, and we want you to know that regardless of the outcome, we\'re rooting for your success.</p></div>' +
+'<p class="closing-text">Keep moving forward, and remember that this is just one step in your educational journey. Your dedication to pursuing higher education is already something to be proud of.</p>' +
+'<div class="signature"><div class="signature-line">Respectfully,</div><div class="signature-line">The Campus Ready Foundation Team</div><div class="signature-title">Supporting students on their path to success</div></div>' +
+'</div>' +
+'<div class="footer"><h4>Questions? We\'re here to help!</h4>' +
+'<p>Email us at <a href="mailto:apply@campusready.org" class="contact-link">apply@campusready.org</a></p>' +
+'<div class="important-note"><strong>Important:</strong> Save your Application ID (<strong>' + applicationId + '</strong>) for future reference</div>' +
+'</div></div></body></html>';
+}
+
+// === HTML PAGES ===
+function createSuccessPage(data, applicationId) {
+  const firstName = data.student_name ? data.student_name.split(' ')[0] : 'Student';
+  const submittedDate = new Date().toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  });
+  const gclid = data.gclid || '';
+
+  const html = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">' +
+'<title>Application Submitted - Campus Ready Foundation</title>' +
+'<script async src="https://www.googletagmanager.com/gtag/js?id=AW-17798681592"></script>' +
+'<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}' +
+'gtag("js",new Date());gtag("config","AW-17798681592");' +
+'gtag("event","conversion",{"send_to":"AW-17798681592/64eLCKSSwdAbEPiniadC","value":1.0,"currency":"USD","transaction_id":"' + applicationId + '","gclid":"' + gclid + '"});' +
+'</script>' +
+'<style>' +
+'body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; background: linear-gradient(135deg, #14b8a6 0%, #0891b2 100%); margin: 0; padding: 20px; min-height: 100vh; display: flex; align-items: center; justify-content: center; }' +
+'.container { background: white; border-radius: 16px; box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1); padding: 48px; max-width: 600px; width: 100%; text-align: center; }' +
+'.success-icon { width: 80px; height: 80px; background: #10b981; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto 24px; }' +
+'.checkmark { width: 40px; height: 40px; color: white; font-size: 30px; font-weight: bold; }' +
+'h1 { color: #1f2937; font-size: 32px; font-weight: 700; margin: 0 0 16px; }' +
+'.subtitle { color: #6b7280; font-size: 18px; margin-bottom: 32px; line-height: 1.6; }' +
+'.details-box { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 12px; padding: 24px; margin: 32px 0; text-align: left; }' +
+'.detail-row { display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid #e5e7eb; }' +
+'.detail-row:last-child { border-bottom: none; }' +
+'.detail-label { font-weight: 600; color: #374151; }' +
+'.detail-value { color: #6b7280; font-family: Monaco, monospace; }' +
+'.next-steps { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 12px; padding: 24px; margin: 32px 0; text-align: left; }' +
+'.next-steps h3 { color: #1e40af; margin: 0 0 16px; font-size: 18px; }' +
+'.next-steps ol { margin: 0; padding-left: 20px; color: #374151; }' +
+'.next-steps li { margin-bottom: 8px; line-height: 1.5; }' +
+'.email-notice { background: #fef3c7; border: 2px solid #f59e0b; border-radius: 8px; padding: 16px; margin: 24px 0; color: #92400e; text-align: left; line-height: 1.5; }' +
+'.actions { display: flex; gap: 16px; justify-content: center; margin-top: 32px; flex-wrap: wrap; }' +
+'.btn { padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; border: none; cursor: pointer; font-size: 16px; }' +
+'.btn-primary { background: #14b8a6; color: white; }' +
+'.btn-primary:hover { background: #0d9488; }' +
+'.btn-secondary { background: white; color: #374151; border: 2px solid #d1d5db; }' +
+'.contact-info { margin-top: 32px; padding-top: 24px; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 14px; }' +
+'@media (max-width: 640px) { .container { padding: 32px 24px; } h1 { font-size: 24px; } .actions { flex-direction: column; } .detail-row { flex-direction: column; align-items: flex-start; gap: 4px; } }' +
+'</style></head><body>' +
+'<div class="container">' +
+'<div class="success-icon"><div class="checkmark">✓</div></div>' +
+'<h1>Application Successfully Submitted!</h1>' +
+'<p class="subtitle">Thank you, <strong>' + firstName + '</strong>! We\'ve received your Campus Ready Foundation grant application and will begin our review process.</p>' +
+'<div class="details-box">' +
+'<div class="detail-row"><span class="detail-label">Application ID:</span><span class="detail-value">' + applicationId + '</span></div>' +
+'<div class="detail-row"><span class="detail-label">Submitted:</span><span class="detail-value">' + submittedDate + '</span></div>' +
+'<div class="detail-row"><span class="detail-label">College:</span><span class="detail-value">' + (data.college || 'Not specified') + '</span></div>' +
+'<div class="detail-row"><span class="detail-label">Email:</span><span class="detail-value">' + (data.student_email || 'Not provided') + '</span></div>' +
+'</div>' +
+'<div class="email-notice"><strong>📧 Confirmation email on the way.</strong> You\'ll receive a confirmation email within the next hour. If it doesn\'t arrive (check your spam folder first), email us at <a href="mailto:apply@campusready.org" style="color:#92400e;"><strong>apply@campusready.org</strong></a> with your Application ID above.</div>' +
+'<div class="next-steps">' +
+'<h3>📋 What Happens Next</h3>' +
+'<ol>' +
+'<li><strong>Save this page:</strong> Your Application ID is your record of submission</li>' +
+'<li><strong>Review Period:</strong> Our board will review all applications after the May 15 deadline</li>' +
+'<li><strong>Decision Notification:</strong> All applicants will be notified of decisions by <strong>June 1</strong></li>' +
+'<li><strong>If Selected:</strong> We\'ll contact you about your Campus Ready Essentials Kit and ongoing support</li>' +
+'</ol>' +
+'</div>' +
+'<div class="actions">' +
+'<a href="https://campusready.org" class="btn btn-primary">Return to Campus Ready</a>' +
+'<button onclick="window.print()" class="btn btn-secondary">Save This Page</button>' +
+'</div>' +
+'<div class="contact-info"><strong>Questions?</strong> Contact us at <a href="mailto:apply@campusready.org" style="color: #14b8a6;">apply@campusready.org</a><br><br><strong>Important:</strong> Please save your Application ID (' + applicationId + ') for future reference.</div>' +
+'</div></body></html>';
+
+  return HtmlService.createHtmlOutput(html);
+}
+
+function createAlreadySubmittedPage(existingAppId, data) {
+  const firstName = (data && data.student_name) ? data.student_name.split(' ')[0] : 'Student';
+
+  const html = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">' +
+'<title>Application Already Received - Campus Ready Foundation</title>' +
+'<style>' +
+'body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; background: linear-gradient(135deg, #14b8a6 0%, #0891b2 100%); margin: 0; padding: 20px; min-height: 100vh; display: flex; align-items: center; justify-content: center; }' +
+'.container { background: white; border-radius: 16px; box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1); padding: 48px; max-width: 600px; width: 100%; text-align: center; }' +
+'.icon { width: 80px; height: 80px; background: #0d9488; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto 24px; color: white; font-size: 40px; font-weight: bold; }' +
+'h1 { color: #1f2937; font-size: 28px; font-weight: 700; margin: 0 0 16px; }' +
+'.subtitle { color: #6b7280; font-size: 18px; margin-bottom: 32px; line-height: 1.6; }' +
+'.details-box { background: #f0fdfa; border: 2px solid #99f6e4; border-radius: 12px; padding: 24px; margin: 32px 0; }' +
+'.detail-label { font-weight: 600; color: #374151; font-size: 14px; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px; }' +
+'.detail-value { color: #0f766e; font-family: Monaco, monospace; font-weight: 600; font-size: 18px; word-break: break-all; }' +
+'.contact-info { margin-top: 32px; padding-top: 24px; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 14px; line-height: 1.6; }' +
+'.btn { background: #14b8a6; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; display: inline-block; margin-top: 16px; }' +
+'</style></head><body>' +
+'<div class="container">' +
+'<div class="icon">✓</div>' +
+'<h1>We Already Have Your Application</h1>' +
+'<p class="subtitle">Hi ' + escapeHtml(firstName) + ' — our records show we\'ve already received your Campus Ready Foundation grant application for this cycle. You don\'t need to submit again.</p>' +
+'<div class="details-box">' +
+'<div class="detail-label">Your Application ID</div>' +
+'<div class="detail-value">' + escapeHtml(existingAppId) + '</div>' +
+'</div>' +
+'<div class="contact-info">' +
+'<strong>Need to correct something?</strong><br>' +
+'Email <a href="mailto:apply@campusready.org" style="color:#14b8a6;">apply@campusready.org</a> with your Application ID and we\'ll help you.<br><br>' +
+'All applicants will be notified of decisions by <strong>June 1</strong>.' +
+'</div>' +
+'<a href="https://campusready.org" class="btn">Return to Campus Ready</a>' +
+'</div></body></html>';
+
+  return HtmlService.createHtmlOutput(html);
+}
+
+function createErrorPage(error) {
+  const errorHtml = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">' +
+'<title>Submission Error - Campus Ready Foundation</title>' +
+'<style>' +
+'body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; background: #fef2f2; margin: 0; padding: 20px; min-height: 100vh; display: flex; align-items: center; justify-content: center; }' +
+'.container { background: white; border-radius: 12px; border: 1px solid #fecaca; padding: 40px; max-width: 500px; width: 100%; text-align: center; }' +
+'.error-icon { color: #dc2626; font-size: 48px; margin-bottom: 16px; }' +
+'h1 { color: #dc2626; margin-bottom: 16px; }' +
+'p { color: #6b7280; margin-bottom: 24px; line-height: 1.6; }' +
+'.btn { background: #14b8a6; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; }' +
+'</style></head><body>' +
+'<div class="container">' +
+'<div class="error-icon">⚠️</div>' +
+'<h1>Submission Error</h1>' +
+'<p>We encountered an issue processing your application. Please try again or contact us for assistance.</p>' +
+'<p><strong>Error:</strong> ' + String(error) + '</p>' +
+'<a href="javascript:history.back()" class="btn">Try Again</a>' +
+'</div></body></html>';
+  return HtmlService.createHtmlOutput(errorHtml);
+}
+
+// === UTILITY HELPERS ===
+function getMasterSheet() {
+  const ss = SpreadsheetApp.openById(CONFIG.SPREADSHEET_ID);
+  const sheet = ss.getSheetByName(CONFIG.MASTER_SHEET_NAME);
+  if (!sheet) throw new Error('Master sheet not found');
+  return sheet;
+}
+
+function findNextAvailableRow(sheet) {
+  const values = sheet.getRange('A:A').getValues();
+  for (let i = 1; i < values.length; i++) {
+    const rowNumber = i + 1;
+    const cellValue = values[i][0];
+    if (cellValue === '' || cellValue === null || cellValue === undefined) {
+      const formula = sheet.getRange(rowNumber, 1).getFormula();
+      if (!formula) return rowNumber;
+    }
+    if (i >= 4999) return sheet.getLastRow() + 1;
+  }
+  return sheet.getLastRow() + 1;
+}
+
+function generateApplicationId() {
+  return 'CR_' + new Date().getTime() + '_' + Math.random().toString(36).substr(2, 6);
+}
+
+function computeCycleYear(date) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  return month < 5 ? year : year + 1;
+}
+
+function isGuardianRequired(data) {
+  if (data.is_minor === 'Yes') return true;
+  if (data.student_dob) {
+    const dob = new Date(data.student_dob);
+    if (!isNaN(dob.getTime())) {
+      const now = new Date();
+      let age = now.getFullYear() - dob.getFullYear();
+      const monthDiff = now.getMonth() - dob.getMonth();
+      if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dob.getDate())) age--;
+      return age < 18;
+    }
+  }
+  return false;
+}
+
+function getConsentSentence(data) {
+  return data.consent_sentence ||
+    'I agree to electronic records and signatures. I certify that I am the named applicant and intend my electronic signature to be legally binding.';
+}
+
+function countWords(text) {
+  if (!text || typeof text !== 'string') return 0;
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+function truncateText(text, maxLength) {
+  if (!text) return '';
+  if (text.length <= maxLength) return text;
+  return text.substring(0, maxLength - 3) + '...';
+}
+
+function toBool(value) {
+  if (typeof value === 'boolean') return value;
+  if (value == null) return false;
+  const str = String(value).trim().toLowerCase();
+  return ['true', 'on', '1', 'yes'].indexOf(str) !== -1;
+}
+
+function cleanIncomeValue(income) {
+  if (!income) return 0;
+  const cleaned = String(income).replace(/[$,\s]/g, '');
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? 0 : num;
+}
+
+function buildHouseholdCircumstances(data) {
+  if (!data.household_circumstances) return '';
+  let circumstances = [];
+  if (Array.isArray(data.household_circumstances)) {
+    circumstances = data.household_circumstances;
+  } else if (typeof data.household_circumstances === 'string') {
+    circumstances = [data.household_circumstances];
+  }
+  return circumstances.join(', ');
+}
+
+function buildAffordabilityConcerns(data) {
+  if (!data.affordability_concerns) return '';
+  let concerns = [];
+  if (Array.isArray(data.affordability_concerns)) {
+    concerns = data.affordability_concerns.slice();
+  } else {
+    concerns = [String(data.affordability_concerns)];
+  }
+  if (concerns.indexOf('other') !== -1 && data.other_concern_text) {
+    const index = concerns.indexOf('other');
+    concerns[index] = 'Other: ' + data.other_concern_text;
+  }
+  return concerns.join(', ');
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// === TESTING / DIAGNOSTIC FUNCTIONS ===
+function validateConfiguration() {
+  const issues = [];
+  try {
+    SpreadsheetApp.openById(CONFIG.SPREADSHEET_ID);
+    console.log('✓ Spreadsheet access: OK');
+  } catch (err) { issues.push('✗ Spreadsheet access: ' + err.message); }
+
+  try {
+    const sheet = getMasterSheet();
+    if (sheet) console.log('✓ Master sheet: OK');
+  } catch (err) { issues.push('✗ Master sheet: ' + err.message); }
+
+  try {
+    const folder = DriveApp.getFolderById(CONFIG.PDF_FOLDER_ID);
+    console.log('✓ PDF folder: ' + folder.getName());
+  } catch (err) { issues.push('✗ PDF folder: ' + err.message); }
+
+  try {
+    getPendingDataSheet();
+    console.log('✓ PendingData sheet: OK');
+  } catch (err) { issues.push('✗ PendingData sheet: ' + err.message); }
+
+  return issues.length === 0 ? '✓ All validations passed' : 'Issues:\n' + issues.join('\n');
+}
+
+// Simulates a sync doPost with mock data. Writes a row with Pending Processing.
+// Leave on staging; do not run on production.
+function testSyncPath() {
+  const mockEvent = {
+    postData: {
+      contents: 'student_name=Sync%20Test&student_email=synctest_' + Date.now() + '%40example.com' +
+        '&student_address=123%20Test%20St&student_city_name=Napa&student_state=CA&student_zip=94559' +
+        '&college=Test%20University&college_address=456%20College%20Ave&college_city_name=Davis' +
+        '&college_state=CA&college_zip=95616&household_members=4&household_income=48000' +
+        '&essay1=This%20is%20a%20test%20essay&essay2=Another%20test%20essay' +
+        '&applicant_typed_name=Sync%20Test&certify=on'
+    }
+  };
+  const result = doPost(mockEvent);
+  console.log('Sync path complete. Check Master for Pending Processing row.');
+  return 'Done. Check logs.';
+}
+
+// Manually fire the background worker (e.g., from the editor while testing)
+function testBackgroundPath() {
+  processBackgroundQueue();
+  return 'Background run complete. Check logs.';
+}
+
+// === COMPATIBILITY ===
+// Use this in any sheet formula that needs distance:
+//   =getDistanceByZip("94558", "95616")
+function getDistanceByZip(homeZip, collegeZip) {
+  return calculateDistance({ student_zip: homeZip, college_zip: collegeZip });
+}
+
+// The old address-based shim. After the 2026 ZIP-only refactor, this no longer
+// works because calculateDistance requires ZIPs. Returns a clear error so any
+// orphaned sheet formula surfaces immediately instead of silently writing junk.
+function getDistance(originAddress, destinationAddress) {
+  return 'getDistance() is deprecated. Use =getDistanceByZip(homeZip, collegeZip) instead.';
+}

--- a/apps-script/Board_Score_Import.gs
+++ b/apps-script/Board_Score_Import.gs
@@ -1,0 +1,524 @@
+/**
+ * Campus Ready Foundation — Board Essay Score Import
+ * Single-step: click "Import Board Scores", review the preview window,
+ * click Proceed to apply or Cancel to abort.
+ *
+ * Menu wiring lives in Applications_Admin_Script.gs (single onOpen per project).
+ */
+
+// Reviewer source spreadsheet IDs.
+const ERIC_SHEET_ID  = '15uZHKaIFwcTzvbRtFwscus7AqzKHFaW2geZit-Yujr8';
+const KAREN_SHEET_ID = '11UmeceKEd73j06FjhU6itezwhF2F5SxoLZy9690dLfk';
+const JANIE_SHEET_ID = '1es0Ul3mJ1Mxz227Qa6Xr_yhJN5cNpkDcg83kGznGsmc';
+
+// Set to true only on the final import run after all three reviewers have finished scoring.
+const LOG_MISSING_SCORES = false;
+
+const REVIEWERS = [
+  { name: 'Eric Lilavois',  sheetId: ERIC_SHEET_ID,
+    essay1Col: 'Eric Lilavois Essay 1 Score',  essay2Col: 'Eric Lilavois Essay 2 Score' },
+  { name: 'Karen Dantzler', sheetId: KAREN_SHEET_ID,
+    essay1Col: 'Karen Dantzler Essay 1 Score', essay2Col: 'Karen Dantzler Essay 2 Score' },
+  { name: 'Janie Green',    sheetId: JANIE_SHEET_ID,
+    essay1Col: 'Janie Green Essay 1 Score',    essay2Col: 'Janie Green Essay 2 Score' },
+];
+
+const SCORING_TAB       = 'Scoring Sheet';
+const SOURCE_HEADER_SCAN_ROWS = 10; // Auto-detect: scan first N rows of each Scoring Sheet for 'Student Name'
+const DEST_TAB          = 'Board_Essays';
+const NOTES_TAB         = 'Board Notes';
+const LOG_TAB           = 'Import Log';
+const HEADER_SCAN_ROWS  = 5;
+
+const SRC_NAME_HEADER  = 'Student Name';
+const SRC_NOTES_HEADER = 'Notes (optional)';
+const SRC_ESSAY1_HEADERS = ['Essay 1\n(1-10)', 'Essay 1 (1-10)', 'Essay 1(1-10)'];
+const SRC_ESSAY2_HEADERS = ['Essay 2\n(1-10)', 'Essay 2 (1-10)', 'Essay 2(1-10)'];
+
+const DEST_NAME_HEADER  = 'Name';
+const ESSAY1_AVG_HEADER = 'Essay 1 Avg';
+const ESSAY2_AVG_HEADER = 'Essay 2 Avg';
+
+// ============================================
+// MENU ENTRY POINT (single item)
+// onOpen lives in Applications_Admin_Script.gs
+// ============================================
+
+function importBoardScores() {
+  const result = analyzeBoardScores();
+  if (result.fatalError) {
+    SpreadsheetApp.getUi().alert(result.fatalError);
+    return;
+  }
+  const html = HtmlService.createHtmlOutput(buildPreviewHtml(result))
+    .setWidth(900).setHeight(650);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Board Score Import — Review Before Applying');
+}
+
+// Called from the dialog's Proceed button.
+function executeBoardScoreImport() {
+  const result = analyzeBoardScores();
+  if (result.fatalError) {
+    return { ok: false, message: result.fatalError };
+  }
+  applyImport(result);
+  return {
+    ok: true,
+    changes:     result.counters.changes,
+    unchanged:   result.counters.unchanged,
+    avgChanges:  result.counters.avgChanges,
+    notes:       result.notes.length,
+    skipped:     result.counters.skipped,
+    errors:      result.errors.length,
+  };
+}
+
+// ============================================
+// ANALYSIS (no writes)
+// ============================================
+
+function analyzeBoardScores() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const errors = [];
+  const notes = [];
+  const writes = [];
+  const counters = { changes: 0, unchanged: 0, avgChanges: 0, skipped: 0 };
+
+  const destSheet = ss.getSheetByName(DEST_TAB);
+  if (!destSheet) return { fatalError: 'Destination tab "' + DEST_TAB + '" not found.' };
+
+  const destData = destSheet.getDataRange().getValues();
+  if (destData.length === 0) return { fatalError: 'Destination tab "' + DEST_TAB + '" is empty.' };
+
+  const headerRowIdx = findHeaderRowIdx(destData, DEST_NAME_HEADER, HEADER_SCAN_ROWS);
+  if (headerRowIdx === -1) {
+    return { fatalError: 'Could not find header "' + DEST_NAME_HEADER +
+      '" in the first ' + HEADER_SCAN_ROWS + ' rows of ' + DEST_TAB + '.' };
+  }
+
+  const destHeaders = destData[headerRowIdx].map(String);
+  const destNameCol = destHeaders.indexOf(DEST_NAME_HEADER);
+
+  const originalDestData = destData.map(row => row.slice());
+
+  const nameToRow = {};
+  for (let r = headerRowIdx + 1; r < destData.length; r++) {
+    const n = normalizeName(destData[r][destNameCol]);
+    if (n) nameToRow[n] = r;
+  }
+
+  const reviewerCols = REVIEWERS.map(r => ({
+    e1: destHeaders.indexOf(r.essay1Col),
+    e2: destHeaders.indexOf(r.essay2Col),
+  }));
+
+  REVIEWERS.forEach((reviewer, rIdx) => {
+    if (!reviewer.sheetId || reviewer.sheetId.indexOf('REPLACE_WITH') === 0) {
+      errors.push({ reviewer: reviewer.name, student: '', reason: 'Sheet ID not configured' });
+      return;
+    }
+
+    let srcSs;
+    try {
+      srcSs = SpreadsheetApp.openById(reviewer.sheetId);
+    } catch (e) {
+      errors.push({ reviewer: reviewer.name, student: '',
+        reason: 'Cannot open source sheet: ' + e.message });
+      return;
+    }
+
+    const srcSheet = srcSs.getSheetByName(SCORING_TAB);
+    if (!srcSheet) {
+      errors.push({ reviewer: reviewer.name, student: '',
+        reason: 'Tab "' + SCORING_TAB + '" not found' });
+      return;
+    }
+
+    const srcValues = srcSheet.getDataRange().getValues();
+    if (srcValues.length === 0) return;
+
+    const srcHeaderRowIdx = findHeaderRowIdx(srcValues, SRC_NAME_HEADER, SOURCE_HEADER_SCAN_ROWS);
+    if (srcHeaderRowIdx === -1) {
+      errors.push({ reviewer: reviewer.name, student: '',
+        reason: 'Could not find "' + SRC_NAME_HEADER + '" in first ' +
+                SOURCE_HEADER_SCAN_ROWS + ' rows of "' + SCORING_TAB + '" tab' });
+      return;
+    }
+
+    const srcHeaders = srcValues[srcHeaderRowIdx].map(String);
+    const nameIdx   = srcHeaders.indexOf(SRC_NAME_HEADER);
+    const essay1Idx = findFirstHeader(srcHeaders, SRC_ESSAY1_HEADERS);
+    const essay2Idx = findFirstHeader(srcHeaders, SRC_ESSAY2_HEADERS);
+    const notesIdx  = srcHeaders.indexOf(SRC_NOTES_HEADER);
+
+    if (nameIdx === -1 || essay1Idx === -1 || essay2Idx === -1) {
+      errors.push({ reviewer: reviewer.name, student: '',
+        reason: 'Required header missing in source sheet (need Student Name, Essay 1, Essay 2)' });
+      return;
+    }
+
+    const dE1 = reviewerCols[rIdx].e1;
+    const dE2 = reviewerCols[rIdx].e2;
+    if (dE1 === -1 || dE2 === -1) {
+      errors.push({ reviewer: reviewer.name, student: '',
+        reason: 'Reviewer column missing in ' + DEST_TAB });
+      return;
+    }
+
+        for (let i = srcHeaderRowIdx + 1; i < srcValues.length; i++) {
+      const row = srcValues[i];
+      const studentName = (row[nameIdx] == null ? '' : String(row[nameIdx])).trim();
+      if (!studentName) continue;
+
+      const destRow = nameToRow[normalizeName(studentName)];
+      if (destRow === undefined) {
+        errors.push({ reviewer: reviewer.name, student: studentName,
+          reason: 'No matching student in ' + DEST_TAB });
+        counters.skipped++;
+        continue;
+      }
+
+      processScore(row[essay1Idx], 'Essay 1', dE1, destRow, reviewer, studentName,
+                   destData, writes, errors, counters);
+      processScore(row[essay2Idx], 'Essay 2', dE2, destRow, reviewer, studentName,
+                   destData, writes, errors, counters);
+
+      const note = notesIdx === -1 ? '' :
+        (row[notesIdx] == null ? '' : String(row[notesIdx]).trim());
+      if (note) notes.push({ student: studentName, reviewer: reviewer.name, note: note });
+    }
+  });
+
+  // Recompute averages (only where all three reviewer scores are valid).
+  const avg1Col = destHeaders.indexOf(ESSAY1_AVG_HEADER);
+  const avg2Col = destHeaders.indexOf(ESSAY2_AVG_HEADER);
+  const reviewerE1Cols = reviewerCols.map(c => c.e1);
+  const reviewerE2Cols = reviewerCols.map(c => c.e2);
+
+  for (let r = headerRowIdx + 1; r < destData.length; r++) {
+    const studentName = String(destData[r][destNameCol] || '').trim();
+    if (!studentName) continue;
+
+    if (avg1Col !== -1) {
+      const vals = reviewerE1Cols.map(c => c === -1 ? null : destData[r][c]);
+      const newAvg = vals.every(isValidScore) ? avg(vals) : '';
+      const oldAvg = originalDestData[r][avg1Col];
+      if (newAvg !== oldAvg) {
+        writes.push({ type: 'avg', reviewer: '(calculated)', student: studentName,
+          cell: 'Essay 1 Avg', oldValue: oldAvg, newValue: newAvg });
+        counters.avgChanges++;
+      }
+      destData[r][avg1Col] = newAvg;
+    }
+
+    if (avg2Col !== -1) {
+      const vals = reviewerE2Cols.map(c => c === -1 ? null : destData[r][c]);
+      const newAvg = vals.every(isValidScore) ? avg(vals) : '';
+      const oldAvg = originalDestData[r][avg2Col];
+      if (newAvg !== oldAvg) {
+        writes.push({ type: 'avg', reviewer: '(calculated)', student: studentName,
+          cell: 'Essay 2 Avg', oldValue: oldAvg, newValue: newAvg });
+        counters.avgChanges++;
+      }
+      destData[r][avg2Col] = newAvg;
+    }
+  }
+
+  if (LOG_MISSING_SCORES) {
+    for (let r = headerRowIdx + 1; r < destData.length; r++) {
+      const studentName = String(destData[r][destNameCol] || '').trim();
+      if (!studentName) continue;
+      REVIEWERS.forEach((reviewer, rIdx) => {
+        const c1 = reviewerCols[rIdx].e1;
+        const c2 = reviewerCols[rIdx].e2;
+        if (c1 !== -1 && !isValidScore(destData[r][c1])) {
+          errors.push({ reviewer: reviewer.name, student: studentName,
+            reason: 'Missing Essay 1 score after import' });
+        }
+        if (c2 !== -1 && !isValidScore(destData[r][c2])) {
+          errors.push({ reviewer: reviewer.name, student: studentName,
+            reason: 'Missing Essay 2 score after import' });
+        }
+      });
+    }
+  }
+
+  return {
+    destSheet: destSheet,
+    destData: destData,
+    headerRowIdx: headerRowIdx,
+    nameToRow: nameToRow,
+    reviewerCols: reviewerCols,
+    avg1Col: avg1Col,
+    avg2Col: avg2Col,
+    writes: writes,
+    errors: errors,
+    notes: notes,
+    counters: counters,
+  };
+}
+
+// ============================================
+// APPLY (writes)
+// ============================================
+
+function applyImport(result) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  writeBackChangedColumns(result.destSheet, result.destData, result.nameToRow,
+                          result.reviewerCols, result.avg1Col, result.avg2Col);
+  writeBoardNotes(ss, result.notes);
+  writeImportLog(ss, result.errors);
+}
+
+// ============================================
+// HELPERS
+// ============================================
+
+function processScore(rawValue, essayLabel, destCol, destRow, reviewer, studentName,
+                      destData, writes, errors, counters) {
+  if (isBlank(rawValue)) return;
+
+  if (!isValidScore(rawValue)) {
+    errors.push({ reviewer: reviewer.name, student: studentName,
+      reason: essayLabel + ' score invalid: "' + rawValue + '"' });
+    counters.skipped++;
+    return;
+  }
+
+  const newVal = Number(rawValue);
+  const oldVal = destData[destRow][destCol];
+
+  if (newVal !== oldVal) {
+    writes.push({ type: 'score', reviewer: reviewer.name, student: studentName,
+      cell: essayLabel + ' Score', oldValue: oldVal, newValue: newVal });
+    counters.changes++;
+  } else {
+    counters.unchanged++;
+  }
+  destData[destRow][destCol] = newVal;
+}
+
+function findHeaderRowIdx(data, requiredHeader, maxRowsToScan) {
+  const max = Math.min(maxRowsToScan, data.length);
+  for (let r = 0; r < max; r++) {
+    if (data[r].map(String).indexOf(requiredHeader) !== -1) return r;
+  }
+  return -1;
+}
+
+function findFirstHeader(headers, candidates) {
+  for (let i = 0; i < candidates.length; i++) {
+    const idx = headers.indexOf(candidates[i]);
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+function isBlank(v) { return v === '' || v === null || v === undefined; }
+
+function isValidScore(v) {
+  if (isBlank(v)) return false;
+  const n = Number(v);
+  if (isNaN(n)) return false;
+  if (n !== Math.floor(n)) return false;
+  return n >= 1 && n <= 10;
+}
+
+function avg(vals) {
+  let s = 0;
+  vals.forEach(v => s += Number(v));
+  return s / vals.length;
+}
+
+function normalizeName(s) {
+  if (s == null) return '';
+  return String(s).trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function writeBackChangedColumns(destSheet, destData, nameToRow, reviewerCols, avg1Col, avg2Col) {
+  const studentRows = Object.keys(nameToRow).map(k => nameToRow[k]);
+  if (studentRows.length === 0) return;
+
+  const minRow = Math.min.apply(null, studentRows);
+  const maxRow = Math.max.apply(null, studentRows);
+  const numRows = maxRow - minRow + 1;
+
+  const colsToWrite = [];
+  reviewerCols.forEach(c => {
+    if (c.e1 !== -1) colsToWrite.push(c.e1);
+    if (c.e2 !== -1) colsToWrite.push(c.e2);
+  });
+  if (avg1Col !== -1) colsToWrite.push(avg1Col);
+  if (avg2Col !== -1) colsToWrite.push(avg2Col);
+
+  colsToWrite.forEach(col => {
+    const colData = [];
+    for (let r = minRow; r <= maxRow; r++) {
+      colData.push([destData[r][col]]);
+    }
+    destSheet.getRange(minRow + 1, col + 1, numRows, 1).setValues(colData);
+  });
+}
+
+function writeBoardNotes(ss, notes) {
+  let sheet = ss.getSheetByName(NOTES_TAB);
+  if (!sheet) sheet = ss.insertSheet(NOTES_TAB);
+  sheet.clear();
+  const rows = [['Student Name', 'Reviewer', 'Note']];
+  notes.forEach(n => rows.push([n.student, n.reviewer, n.note]));
+  sheet.getRange(1, 1, rows.length, 3).setValues(rows);
+  sheet.setFrozenRows(1);
+}
+
+function writeImportLog(ss, errors) {
+  let sheet = ss.getSheetByName(LOG_TAB);
+  if (!sheet) {
+    sheet = ss.insertSheet(LOG_TAB);
+    sheet.getRange(1, 1, 1, 4).setValues([['Timestamp', 'Reviewer', 'Student Name', 'Reason']]);
+    sheet.setFrozenRows(1);
+  }
+  if (!errors.length) return;
+  const ts = new Date();
+  const rows = errors.map(e => [ts, e.reviewer || '', e.student || '', e.reason || '']);
+  sheet.getRange(sheet.getLastRow() + 1, 1, rows.length, 4).setValues(rows);
+}
+
+// ============================================
+// PREVIEW DIALOG HTML
+// ============================================
+
+function buildPreviewHtml(result) {
+  const esc = function(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  };
+  const fmt = function(v) {
+    if (isBlank(v)) return '<span style="color:#9aa0a6">(blank)</span>';
+    if (typeof v === 'number') return esc(Math.round(v * 100) / 100);
+    return esc(v);
+  };
+
+  const c = result.counters;
+  const hasChanges = result.writes.length > 0 || result.notes.length > 0;
+
+  let html = ''
+    + '<style>'
+    + 'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;padding:14px;color:#202124;margin:0;}'
+    + 'h2{margin:0 0 12px;font-size:18px;}'
+    + 'h3{font-size:12px;margin:18px 0 6px;color:#5f6368;text-transform:uppercase;letter-spacing:.6px;}'
+    + '.summary{background:#f8f9fa;border:1px solid #dadce0;border-radius:6px;padding:10px 14px;}'
+    + '.summary table{width:100%;border-collapse:collapse;}'
+    + '.summary td{padding:3px 6px;font-size:13px;}'
+    + '.summary td:first-child{color:#5f6368;}'
+    + '.summary td:last-child{font-weight:600;text-align:right;}'
+    + '.err{color:#c5221f;}'
+    + 'table.changes{width:100%;border-collapse:collapse;font-size:12px;margin-top:4px;}'
+    + 'table.changes th,table.changes td{padding:5px 8px;border-bottom:1px solid #e8eaed;text-align:left;vertical-align:top;}'
+    + 'table.changes th{background:#f8f9fa;font-weight:600;color:#5f6368;position:sticky;top:0;}'
+    + 'table.changes td.num{font-variant-numeric:tabular-nums;text-align:right;}'
+    + '.none{color:#5f6368;font-style:italic;padding:6px 0;font-size:13px;}'
+    + '.note-cell{max-width:480px;white-space:pre-wrap;}'
+    + '#actions{position:sticky;bottom:0;background:#fff;padding:12px 0 4px;border-top:1px solid #e8eaed;margin-top:18px;text-align:right;}'
+    + 'button{font-size:13px;padding:8px 18px;border-radius:4px;border:1px solid #dadce0;background:#fff;cursor:pointer;margin-left:8px;}'
+    + 'button.primary{background:#1a73e8;color:#fff;border-color:#1a73e8;}'
+    + 'button:disabled{background:#dadce0;border-color:#dadce0;color:#80868b;cursor:default;}'
+    + 'button.primary:disabled{background:#9aa0a6;border-color:#9aa0a6;color:#fff;}'
+    + '#status{margin-right:12px;font-size:13px;color:#1a73e8;}'
+    + '#status.done{color:#137333;font-weight:600;}'
+    + '#status.err{color:#c5221f;font-weight:600;}'
+    + '</style>'
+
+    + '<h2>Review changes before applying</h2>'
+    + '<div class="summary"><table>'
+    + '<tr><td>Score changes to be written</td><td>' + c.changes + '</td></tr>'
+    + '<tr><td>Scores re-imported unchanged</td><td>' + c.unchanged + '</td></tr>'
+    + '<tr><td>Averages to be updated</td><td>' + c.avgChanges + '</td></tr>'
+    + '<tr><td>Notes to be consolidated</td><td>' + result.notes.length + '</td></tr>'
+    + '<tr><td>Skipped (invalid or unmatched)</td><td>' + c.skipped + '</td></tr>'
+    + '<tr><td>Errors / flags</td><td class="' + (result.errors.length ? 'err' : '') + '">' + result.errors.length + '</td></tr>'
+    + '</table></div>'
+
+    + '<h3>Changes</h3>';
+
+  if (result.writes.length === 0) {
+    html += '<div class="none">No changes would be made.</div>';
+  } else {
+    html += '<table class="changes"><thead><tr>'
+      + '<th>Type</th><th>Reviewer</th><th>Student</th><th>Cell</th>'
+      + '<th>Old</th><th>New</th></tr></thead><tbody>';
+    result.writes.forEach(function(w) {
+      html += '<tr>'
+        + '<td>' + esc(w.type) + '</td>'
+        + '<td>' + esc(w.reviewer) + '</td>'
+        + '<td>' + esc(w.student) + '</td>'
+        + '<td>' + esc(w.cell) + '</td>'
+        + '<td class="num">' + fmt(w.oldValue) + '</td>'
+        + '<td class="num">' + fmt(w.newValue) + '</td>'
+        + '</tr>';
+    });
+    html += '</tbody></table>';
+  }
+
+  if (result.errors.length) {
+    html += '<h3>Errors / Flags</h3>'
+      + '<table class="changes"><thead><tr>'
+      + '<th>Reviewer</th><th>Student</th><th>Reason</th></tr></thead><tbody>';
+    result.errors.forEach(function(e) {
+      html += '<tr>'
+        + '<td>' + esc(e.reviewer) + '</td>'
+        + '<td>' + esc(e.student) + '</td>'
+        + '<td class="err">' + esc(e.reason) + '</td>'
+        + '</tr>';
+    });
+    html += '</tbody></table>';
+  }
+
+  if (result.notes.length) {
+    html += '<h3>Notes to consolidate</h3>'
+      + '<table class="changes"><thead><tr>'
+      + '<th>Student</th><th>Reviewer</th><th>Note</th></tr></thead><tbody>';
+    result.notes.forEach(function(n) {
+      html += '<tr>'
+        + '<td>' + esc(n.student) + '</td>'
+        + '<td>' + esc(n.reviewer) + '</td>'
+        + '<td class="note-cell">' + esc(n.note) + '</td>'
+        + '</tr>';
+    });
+    html += '</tbody></table>';
+  }
+
+  html += '<div id="actions">'
+    + '<span id="status"></span>'
+    + '<button onclick="google.script.host.close()">Cancel</button>'
+    + '<button id="proceedBtn" class="primary" onclick="proceed()"'
+    + (hasChanges ? '' : ' disabled') + '>Proceed with Import</button>'
+    + '</div>'
+
+    + '<script>'
+    + 'function proceed(){'
+    + '  document.getElementById("proceedBtn").disabled=true;'
+    + '  document.getElementById("status").className="";'
+    + '  document.getElementById("status").innerText="Applying...";'
+    + '  google.script.run'
+    + '    .withSuccessHandler(onDone)'
+    + '    .withFailureHandler(onErr)'
+    + '    .executeBoardScoreImport();'
+    + '}'
+    + 'function onDone(r){'
+    + '  var s=document.getElementById("status");'
+    + '  if(!r.ok){s.className="err";s.innerText="Error: "+r.message;return;}'
+    + '  s.className="done";'
+    + '  s.innerText="Import complete — "+r.changes+" score changes, "+r.avgChanges+" avg updates, "'
+    + '    +r.notes+" notes consolidated, "+r.errors+" errors logged.";'
+    + '}'
+    + 'function onErr(err){'
+    + '  var s=document.getElementById("status");'
+    + '  s.className="err";'
+    + '  s.innerText="Error: "+(err.message||err);'
+    + '  document.getElementById("proceedBtn").disabled=false;'
+    + '}'
+    + '<\/script>';
+
+  return html;
+}

--- a/apps-script/Grant_Fulfillment_Script.gs
+++ b/apps-script/Grant_Fulfillment_Script.gs
@@ -1,0 +1,2463 @@
+// TEST FUNCTION - Run this once to authorize Drive access
+function authorizeDrive() {
+  try {
+    const folder = DriveApp.getFolderById('1ccJ8lg40PTgMFIXdNoXyHU12ySgSnurf');
+    Logger.log('Folder name: ' + folder.getName());
+    return 'Authorization successful!';
+  } catch (error) {
+    Logger.log('Error: ' + error.toString());
+    return error.toString();
+  }
+}
+// === Campus Ready Fulfillment Script v2.1 ===
+// Last updated: Nov 3, 2025
+// Enhancements: Auto-tagging, Resolver inheritance, Filtered Shopping List, Archive Cohort
+// ============================================
+// WEB FORM SUBMISSION HANDLER (for HTML Form)
+// ============================================
+// ============================================
+// EMAIL VALIDATION HANDLER
+// ============================================
+
+/**
+ * Check student status by email
+ * Called from Customize Your Kit form via Vercel proxy
+ * @param {string} email - Student's email address
+ * @returns {Object} Student status and information
+ */
+function checkStudentStatus(email) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Grant_Recipients');
+
+  if (!sheet) {
+    return {
+      status: 'error',
+      message: 'Grant_Recipients sheet not found'
+    };
+  }
+
+  const data = sheet.getDataRange().getValues();
+
+  // Search for email in column C (index 2)
+  for (let i = 1; i < data.length; i++) { // Start at 1 to skip header row
+    if (data[i][2] && data[i][2].toString().toLowerCase() === email.toLowerCase()) {
+      return {
+        status: 'found',
+        applicationId: data[i][0],                    // Column A
+        studentName: data[i][1],                      // Column B
+        email: data[i][2],                            // Column C
+        cohortYear: data[i][3],                       // Column D
+        housingStatus: data[i][5] || 'Pending',       // Column F
+        acceptanceStatus: data[i][7] || 'Pending'     // Column H
+      };
+    }
+  }
+
+  // Email not found
+  return {
+    status: 'not_found'
+  };
+}
+/**
+ * Upload documents to Google Drive and update Grant_Recipients
+ * @param {string} email - Student's email
+ * @param {string} applicationId - Student's application ID
+ * @param {Object} housingFile - Housing document {name, data}
+ * @param {Object} acceptanceFile - Acceptance document {name, data}
+ * @returns {Object} Upload status and URLs
+ */
+function uploadDocuments(email, applicationId, housingFile, acceptanceFile) {
+  try {
+    // === VALIDATION ===
+    Logger.log('=== UPLOAD DOCUMENTS CALLED ===');
+    Logger.log('Email: ' + email);
+    Logger.log('Application ID: ' + applicationId);
+
+    // Validate email and applicationId
+    if (!email || !applicationId) {
+      Logger.log('ERROR: Missing email or applicationId');
+      return {
+        status: 'error',
+        message: 'Missing required parameters: email or applicationId'
+      };
+    }
+
+    // Validate housingFile
+    if (!housingFile) {
+      Logger.log('ERROR: housingFile is null or undefined');
+      return {
+        status: 'error',
+        message: 'Housing file is missing'
+      };
+    }
+
+    if (!housingFile.name) {
+      Logger.log('ERROR: housingFile.name is missing');
+      return {
+        status: 'error',
+        message: 'Housing file name is missing'
+      };
+    }
+
+    if (!housingFile.data) {
+      Logger.log('ERROR: housingFile.data is null or undefined');
+      Logger.log('housingFile object: ' + JSON.stringify(housingFile));
+      return {
+        status: 'error',
+        message: 'Housing file data is missing'
+      };
+    }
+
+    if (typeof housingFile.data !== 'string') {
+      Logger.log('ERROR: housingFile.data is not a string, type: ' + typeof housingFile.data);
+      return {
+        status: 'error',
+        message: 'Housing file data is not in correct format'
+      };
+    }
+
+    if (housingFile.data.length === 0) {
+      Logger.log('ERROR: housingFile.data is empty string');
+      return {
+        status: 'error',
+        message: 'Housing file data is empty'
+      };
+    }
+
+    // Validate acceptanceFile
+    if (!acceptanceFile) {
+      Logger.log('ERROR: acceptanceFile is null or undefined');
+      return {
+        status: 'error',
+        message: 'Acceptance file is missing'
+      };
+    }
+
+    if (!acceptanceFile.name) {
+      Logger.log('ERROR: acceptanceFile.name is missing');
+      return {
+        status: 'error',
+        message: 'Acceptance file name is missing'
+      };
+    }
+
+    if (!acceptanceFile.data) {
+      Logger.log('ERROR: acceptanceFile.data is null or undefined');
+      Logger.log('acceptanceFile object: ' + JSON.stringify(acceptanceFile));
+      return {
+        status: 'error',
+        message: 'Acceptance file data is missing'
+      };
+    }
+
+    if (typeof acceptanceFile.data !== 'string') {
+      Logger.log('ERROR: acceptanceFile.data is not a string, type: ' + typeof acceptanceFile.data);
+      return {
+        status: 'error',
+        message: 'Acceptance file data is not in correct format'
+      };
+    }
+
+    if (acceptanceFile.data.length === 0) {
+      Logger.log('ERROR: acceptanceFile.data is empty string');
+      return {
+        status: 'error',
+        message: 'Acceptance file data is empty'
+      };
+    }
+
+    Logger.log('Validation passed - proceeding with upload');
+    Logger.log('Housing file name: ' + housingFile.name + ', data length: ' + housingFile.data.length);
+    Logger.log('Acceptance file name: ' + acceptanceFile.name + ', data length: ' + acceptanceFile.data.length);
+
+    // === UPLOAD TO DRIVE ===
+    const DRIVE_FOLDER_ID = '1ccJ8lg40PTgMFIXdNoXyHU12ySgSnurf';
+    const folder = DriveApp.getFolderById(DRIVE_FOLDER_ID);
+    Logger.log('Drive folder accessed: ' + folder.getName());
+
+    // Decode base64 and create files
+    Logger.log('Decoding housing file...');
+    const housingBlob = Utilities.newBlob(
+      Utilities.base64Decode(housingFile.data),
+      getMimeType(housingFile.name),
+      applicationId + '_Housing.pdf'
+    );
+    Logger.log('Housing blob created');
+
+    Logger.log('Decoding acceptance file...');
+    const acceptanceBlob = Utilities.newBlob(
+      Utilities.base64Decode(acceptanceFile.data),
+      getMimeType(acceptanceFile.name),
+      applicationId + '_Acceptance.pdf'
+    );
+    Logger.log('Acceptance blob created');
+
+    // Upload to Drive
+    Logger.log('Uploading housing file to Drive...');
+    const housingDriveFile = folder.createFile(housingBlob);
+    Logger.log('Housing file uploaded, ID: ' + housingDriveFile.getId());
+
+    Logger.log('Uploading acceptance file to Drive...');
+    const acceptanceDriveFile = folder.createFile(acceptanceBlob);
+    Logger.log('Acceptance file uploaded, ID: ' + acceptanceDriveFile.getId());
+
+    // Set sharing permissions (try, but don't fail if org restrictions prevent it)
+    try {
+      housingDriveFile.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+      acceptanceDriveFile.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+      Logger.log('Sharing permissions set to ANYONE_WITH_LINK');
+    } catch (sharingError) {
+      Logger.log('Warning: Could not set sharing to ANYONE_WITH_LINK: ' + sharingError.message);
+      Logger.log('Files are uploaded but may require folder permissions for access');
+    }
+
+    // Get shareable URLs
+    const housingUrl = housingDriveFile.getUrl();
+    const acceptanceUrl = acceptanceDriveFile.getUrl();
+    Logger.log('Housing URL: ' + housingUrl);
+    Logger.log('Acceptance URL: ' + acceptanceUrl);
+
+    // === UPDATE GRANT_RECIPIENTS ===
+    Logger.log('Updating Grant_Recipients spreadsheet...');
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.getSheetByName('Grant_Recipients');
+    const data = sheet.getDataRange().getValues();
+
+    for (let i = 1; i < data.length; i++) {
+      if (data[i][2] && data[i][2].toString().toLowerCase() === email.toLowerCase()) {
+        Logger.log('Found student at row ' + (i + 1));
+        sheet.getRange(i + 1, 6).setValue('Uploaded');  // Housing Status (Column F)
+        sheet.getRange(i + 1, 7).setValue(housingUrl);   // Housing Doc URL (Column G)
+        sheet.getRange(i + 1, 8).setValue('Uploaded');   // Acceptance Status (Column H)
+        sheet.getRange(i + 1, 9).setValue(acceptanceUrl); // Acceptance Doc URL (Column I)
+        // Clear rejection tracking on resubmission
+        sheet.getRange(i + 1, 12).setValue('');  // Clear Column L (Rejection Email Sent)
+        Logger.log('Spreadsheet updated successfully');
+        break;
+      }
+    }
+
+    Logger.log('=== UPLOAD COMPLETE ===');
+    return {
+      status: 'success',
+      housingUrl: housingUrl,
+      acceptanceUrl: acceptanceUrl
+    };
+
+  } catch (error) {
+    Logger.log('=== UPLOAD ERROR ===');
+    Logger.log('Error message: ' + error.message);
+    Logger.log('Error stack: ' + error.stack);
+    Logger.log('Error toString: ' + error.toString());
+    return {
+      status: 'error',
+      message: 'Upload failed: ' + error.message
+    };
+  }
+}
+
+function getMimeType(filename) {
+  const extension = filename.split('.').pop().toLowerCase();
+  const mimeTypes = {
+    'pdf': 'application/pdf',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'png': 'image/png'
+  };
+  return mimeTypes[extension] || 'application/octet-stream';
+}
+/**
+ * Receives form submissions from the HTML Customize Your Kit form
+ * @param {Object} e - The POST request object
+ */
+// ============================================
+// REJECTION EMAIL SYSTEM - Added Nov 17, 2025
+// Version: Option C - Two-Column Tracking
+// ============================================
+
+/**
+ * Install triggers for automatic tracking
+ * Called from onOpen()
+ */
+function installTriggers() {
+  // Remove existing triggers to avoid duplicates
+  const triggers = ScriptApp.getProjectTriggers();
+  triggers.forEach(trigger => {
+    if (trigger.getHandlerFunction() === 'onGrantRecipientsEdit') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  });
+
+  // Install edit trigger for Grant_Recipients sheet
+  ScriptApp.newTrigger('onGrantRecipientsEdit')
+    .forSpreadsheet(SpreadsheetApp.getActiveSpreadsheet())
+    .onEdit()
+    .create();
+}
+/**
+ * Handle edits to Grant_Recipients sheet
+ * Clears Column L when status changes to "Approved"
+ */
+function onGrantRecipientsEdit(e) {
+  try {
+    const sheet = e.source.getActiveSheet();
+
+    // Only process edits to Grant_Recipients sheet
+    if (sheet.getName() !== 'Grant_Recipients') {
+      return;
+    }
+
+    const range = e.range;
+    const row = range.getRow();
+    const col = range.getColumn();
+
+    // Only process edits to columns F (6) or H (8) - the status columns
+    if (col !== 6 && col !== 8) {
+      return;
+    }
+
+    // Get the new value
+    const newValue = range.getValue();
+
+    // If status changed to "Approved", clear Column L for this row
+    if (newValue === 'Approved') {
+      // Check if BOTH statuses are approved before clearing
+      const housingStatus = sheet.getRange(row, 6).getValue();
+      const acceptanceStatus = sheet.getRange(row, 8).getValue();
+
+      if (housingStatus === 'Approved' && acceptanceStatus === 'Approved') {
+        sheet.getRange(row, 12).setValue('');  // Clear Column L
+        Logger.log(`Cleared rejection email timestamp for row ${row} - both documents approved`);
+      }
+    }
+  } catch (error) {
+    Logger.log('Error in onGrantRecipientsEdit: ' + error);
+  }
+}
+/**
+ * Send rejection emails to students whose documents were rejected
+ * Shows confirmation dialog before sending
+ */
+function sendRejectionEmails() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Grant_Recipients');
+  const ui = SpreadsheetApp.getUi();
+
+  if (!sheet) {
+    ui.alert('Error', 'Grant_Recipients sheet not found', ui.ButtonSet.OK);
+    return;
+  }
+
+  // Get all data
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+
+  // Find column indices
+  const colIndices = {
+    studentName: 1,      // Column B
+    email: 2,            // Column C
+    housingStatus: 5,    // Column F
+    acceptanceStatus: 7, // Column H
+    emailSent: 11,       // Column L (Rejection Email Sent)
+    rejectionCount: 12   // Column M (Rejection Count)
+  };
+
+  // Find students who need rejection emails
+  const studentsToEmail = [];
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    const housingStatus = row[colIndices.housingStatus];
+    const acceptanceStatus = row[colIndices.acceptanceStatus];
+    const emailSent = row[colIndices.emailSent];
+
+    // Check if either document is rejected AND email not yet sent
+    if ((housingStatus === 'Rejected' || acceptanceStatus === 'Rejected') && !emailSent) {
+      const currentCount = row[colIndices.rejectionCount] || 0;
+
+      studentsToEmail.push({
+        rowIndex: i + 1, // +1 because sheet rows are 1-indexed
+        name: row[colIndices.studentName],
+        email: row[colIndices.email],
+        housingRejected: housingStatus === 'Rejected',
+        acceptanceRejected: acceptanceStatus === 'Rejected',
+        currentRejectionCount: currentCount
+      });
+    }
+  }
+
+  // If no students need emails, inform and exit
+  if (studentsToEmail.length === 0) {
+    ui.alert(
+      'No Emails to Send',
+      'All students with rejected documents have already been emailed.',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // Build confirmation message
+  let confirmMessage = `Ready to send rejection emails to ${studentsToEmail.length} student(s):\n\n`;
+
+  studentsToEmail.forEach(student => {
+    let reason = '';
+    if (student.housingRejected && student.acceptanceRejected) {
+      reason = 'Both documents rejected';
+    } else if (student.housingRejected) {
+      reason = 'Housing rejected';
+    } else {
+      reason = 'Acceptance rejected';
+    }
+
+    // Show rejection count if > 0
+    const countInfo = student.currentRejectionCount > 0
+      ? ` [Rejection #${student.currentRejectionCount + 1}]`
+      : '';
+
+    confirmMessage += `• ${student.name} (${reason})${countInfo}\n`;
+  });
+
+  confirmMessage += '\nDo you want to send these emails?';
+
+  // Show confirmation dialog
+  const response = ui.alert(
+    'Send Rejection Emails',
+    confirmMessage,
+    ui.ButtonSet.YES_NO
+  );
+
+  // If user cancels, exit
+  if (response !== ui.Button.YES) {
+    ui.alert('Cancelled', 'No emails were sent.', ui.ButtonSet.OK);
+    return;
+  }
+
+  // Send emails and track results
+  let successCount = 0;
+  let failCount = 0;
+  const timestamp = new Date();
+
+  studentsToEmail.forEach(student => {
+    try {
+      sendRejectionEmailToStudent(student);
+
+      // Mark email as sent and increment rejection count
+      sheet.getRange(student.rowIndex, colIndices.emailSent + 1).setValue(timestamp);
+      sheet.getRange(student.rowIndex, colIndices.rejectionCount + 1).setValue(student.currentRejectionCount + 1);
+
+      successCount++;
+    } catch (error) {
+      Logger.log(`Failed to send email to ${student.email}: ${error}`);
+      failCount++;
+    }
+  });
+
+  // Show results
+  let resultMessage = `Emails sent successfully: ${successCount}`;
+  if (failCount > 0) {
+    resultMessage += `\nFailed to send: ${failCount}`;
+  }
+
+  ui.alert('Email Results', resultMessage, ui.ButtonSet.OK);
+}
+
+/**
+ * Send rejection email to individual student
+ * @param {Object} student - Student object with name, email, and rejection reasons
+ */
+function sendRejectionEmailToStudent(student) {
+  const subject = 'Campus Ready Grant - Quick Document Update Needed';
+  const formUrl = 'https://ericlilavois.github.io/Campus_Ready_Grant_Fulfillment/Customize_Your_Kit.html';
+
+  // Build email body based on what was rejected
+  let documentSection = '';
+
+  if (student.housingRejected && student.acceptanceRejected) {
+    // Both documents rejected
+    documentSection = `We need clearer copies of both your housing verification and college acceptance letter.
+
+For your housing verification, this could be:
+- Official housing assignment letter from your college
+- Signed housing contract
+- Dorm assignment confirmation email
+
+For your acceptance letter, this could be:
+- Official acceptance letter from the admissions office
+- Enrollment confirmation letter
+- Official email confirming your admission`;
+  } else if (student.housingRejected) {
+    // Only housing rejected
+    documentSection = `We need a clearer copy of your housing contract or dorm assignment. This could be:
+- Official housing assignment letter from your college
+- Signed housing contract
+- Dorm assignment confirmation email`;
+  } else {
+    // Only acceptance rejected
+    documentSection = `We need a clearer copy of your college acceptance letter. This could be:
+- Official acceptance letter from the admissions office
+- Enrollment confirmation letter
+- Official email confirming your admission`;
+  }
+
+  // Build full email body
+  const emailBody = `Hi ${student.name},
+
+We've reviewed the documents you submitted for your Campus Ready grant, and we need just a bit more from you to move forward.
+
+${documentSection}
+
+Please make sure your document:
+✓ Is a clear, readable PDF or photo
+✓ Shows your name and the college name clearly
+✓ Includes the specific confirmation we need (housing assignment or acceptance)
+
+No worries if you don't have the perfect document yet - many students are still waiting on official paperwork. You can come back to the form anytime with updated documents.
+
+Your grant is still reserved for you. We just need this verification to move forward with customizing and delivering your kit.
+
+Ready to resubmit? Use the same link: ${formUrl}
+
+Questions or need help? We're here:
+hello@campusready.com
+
+You've got this!
+
+The Campus Ready Team`;
+
+  // Send email
+  GmailApp.sendEmail(
+    student.email,
+    subject,
+    emailBody,
+    {
+      name: 'Campus Ready Foundation',
+      replyTo: 'hello@campusready.com'
+    }
+  );
+
+  Logger.log(`Rejection email sent to ${student.email} (${student.name})`);
+}
+
+// === END REJECTION EMAIL SYSTEM ===
+function doPost(e) {
+  try {
+    // Parse the incoming JSON data
+    const data = JSON.parse(e.postData.contents);
+    // Route based on action type
+    if (data.action === 'checkStudentStatus') {
+      const result = checkStudentStatus(data.email);
+      return ContentService.createTextOutput(JSON.stringify(result))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
+    // Route uploadDocuments requests
+    if (data.action === 'uploadDocuments') {
+      const result = uploadDocuments(data.email, data.applicationId, data.housingFile, data.acceptanceFile);
+      return ContentService.createTextOutput(JSON.stringify(result))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
+    // If no action specified, assume it's a form submission (existing behavior)
+
+    // Get the active spreadsheet
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+    // Get or create the "Student Selections" sheet
+    let sheet = ss.getSheetByName('Student_Selections');
+
+    if (!sheet) {
+      // Create the sheet if it doesn't exist
+      sheet = ss.insertSheet('Student_Selections');
+
+      // Set up headers
+      const headers = [
+        'Timestamp',
+        'Student Name',
+        'Email Address',
+        'Shipping Preference (home or college)',
+        'Street Address',
+        'Street Address 2',
+        'City',
+        'State',
+        'Zip Code',
+        'Gender Preference',
+        'Scent Preference',
+        'Deodorant Type',
+        'Style Preference',
+        'Bedding Color',
+        'Pillow Firmness',
+        'Towel Color',
+        'Slides Size'
+      ];
+
+      sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+
+      // Format header row
+      sheet.getRange(1, 1, 1, headers.length)
+        .setFontWeight('bold')
+        .setBackground('#469E92')
+        .setFontColor('#FFFFFF');
+
+      // Freeze header row
+      sheet.setFrozenRows(1);
+    }
+
+    // Prepare the row data in the exact order of headers
+    const rowData = [
+(() => {
+  const rawDate = new Date();
+  return rawDate.getFullYear() + '-' +
+    String(rawDate.getMonth() + 1).padStart(2, '0') + '-' +
+    String(rawDate.getDate()).padStart(2, '0') + ' ' +
+    String(rawDate.getHours()).padStart(2, '0') + ':' +
+    String(rawDate.getMinutes()).padStart(2, '0');
+})(),
+      data.student_name || '',
+      data.email || '',
+      data.shipping_preference || '',
+      data.street_address || '',
+      data.street_address_2 || '',
+      data.city || '',
+      data.state || '',
+      data.zip || '',
+      data.gender_preference || '',
+      data.scent_preference || '',
+      data.deodorant_type || '',
+      data.style_preference || '',
+      data.bedding_color || '',
+      data.pillow_firmness || '',
+      data.towel_color || '',
+      data.slides_size || ''
+    ];
+// === BEGIN MOD v2.2 - Pull cohort_year from Grant_Recipients Nov 17, 2025 ===
+    // Look up student's cohort year from Grant_Recipients (not from timestamp)
+    const studentEmail = data.email;
+    let cohortYear = new Date().getFullYear(); // Default fallback
+    let grantRecipientsRowIndex = null;
+
+    const grantRecipientsSheet = ss.getSheetByName('Grant_Recipients');
+    if (grantRecipientsSheet) {
+      const grantRecipientsData = grantRecipientsSheet.getDataRange().getValues();
+
+      // Find student by email (Column C, index 2)
+      for (let i = 1; i < grantRecipientsData.length; i++) {
+        if (grantRecipientsData[i][2] &&
+            grantRecipientsData[i][2].toString().toLowerCase() === studentEmail.toLowerCase()) {
+          cohortYear = grantRecipientsData[i][3] || cohortYear; // Column D (Cohort Year)
+          grantRecipientsRowIndex = i + 1; // Store row number for later update
+          Logger.log(`Found student in Grant_Recipients: cohort_year = ${cohortYear}`);
+          break;
+        }
+      }
+
+      if (!grantRecipientsRowIndex) {
+        Logger.log(`Warning: Student ${studentEmail} not found in Grant_Recipients. Using default year ${cohortYear}`);
+      }
+    } else {
+      Logger.log('Warning: Grant_Recipients sheet not found. Using default year.');
+    }
+
+    // Append tagging columns: data_type = "Live", cohort_year from Grant_Recipients
+    rowData.push("Live"); // data_type
+    rowData.push(cohortYear); // cohort_year from Grant_Recipients
+    // === END MOD v2.2 ===
+
+    // Append the data to the sheet
+    sheet.appendRow(rowData);
+
+    // ============================================
+    // NEW: Automatically process this submission
+    // ============================================
+    try {
+      processLatestSubmission(ss);
+      Logger.log('✅ Resolver processing completed for new submission');
+    } catch (resolverError) {
+      Logger.log('⚠️ Warning: Resolver failed but form data was saved');
+      Logger.log(resolverError.message);
+      // Continue - don't fail the form submission if resolver has issues
+    }
+    // === BEGIN MOD v2.2 - Update Grant_Recipients on form submission Nov 17, 2025 ===
+    // Update Grant_Recipients to mark Items Selected = Yes and add Submission Timestamp
+    if (grantRecipientsRowIndex && grantRecipientsSheet) {
+      try {
+        const submissionTimestamp = Utilities.formatDate(
+          new Date(),
+          Session.getScriptTimeZone(),
+          'yyyy-MM-dd HH:mm:ss'
+        );
+
+        grantRecipientsSheet.getRange(grantRecipientsRowIndex, 10).setValue('Yes'); // Column J - Items Selected
+        grantRecipientsSheet.getRange(grantRecipientsRowIndex, 11).setValue(submissionTimestamp); // Column K - Submission Timestamp
+
+        Logger.log(`Updated Grant_Recipients row ${grantRecipientsRowIndex}: Items Selected = Yes, Timestamp = ${submissionTimestamp}`);
+      } catch (updateError) {
+        Logger.log('Warning: Failed to update Grant_Recipients: ' + updateError.message);
+        // Don't fail the submission if this update fails
+      }
+    }
+    // === END MOD v2.2 ===
+    // Return success response
+    return ContentService
+      .createTextOutput(JSON.stringify({
+        'status': 'success',
+        'message': 'Form submitted successfully'
+      }))
+      .setMimeType(ContentService.MimeType.JSON);
+
+  } catch (error) {
+    // Log the error
+    console.error('Error processing form submission:', error);
+
+    // Return error response
+    return ContentService
+      .createTextOutput(JSON.stringify({
+        'status': 'error',
+        'message': error.toString()
+      }))
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+}
+
+// ============================================
+// NEW FUNCTION: Process Latest Submission
+// ============================================
+
+/**
+ * Processes the most recent submission from Student Selections
+ * and writes resolved products to Resolver sheet
+ * @param {Spreadsheet} ss - The active spreadsheet (optional)
+ */
+function processLatestSubmission(ss) {
+  if (!ss) {
+    ss = SpreadsheetApp.getActiveSpreadsheet();
+  }
+
+  Logger.log('=== PROCESSING LATEST SUBMISSION ===');
+
+  // Load Product Logic data
+  let logicData;
+  try {
+    logicData = loadLogicTable(ss);
+    Logger.log(`✅ Loaded ${logicData.length} products from Product_Logic sheet`);
+  } catch (error) {
+    Logger.log(`❌ CRITICAL ERROR: Failed to load Product_Logic sheet`);
+    Logger.log(error.message);
+    throw error;
+  }
+
+  // Get the most recent row from Student Selections
+  const selectionsSheet = ss.getSheetByName('Student_Selections');
+  if (!selectionsSheet) {
+    throw new Error('Student Selections sheet not found');
+  }
+
+  const lastRow = selectionsSheet.getLastRow();
+  if (lastRow < 2) {
+    throw new Error('No data in Student Selections sheet');
+  }
+
+  // Get headers and the latest data row
+  const headers = selectionsSheet.getRange(1, 1, 1, selectionsSheet.getLastColumn()).getValues()[0];
+  const latestRowData = selectionsSheet.getRange(lastRow, 1, 1, selectionsSheet.getLastColumn()).getValues()[0];
+
+  // Create header map
+  const headerMap = {};
+  headers.forEach((h, i) => headerMap[h] = i);
+
+  // Extract student choices from the latest row
+  const studentChoices = {
+    Timestamp: latestRowData[headerMap['Timestamp']] || Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm'),
+    StudentName: latestRowData[headerMap['Student Name']] || '',
+    Email: latestRowData[headerMap['Email Address']] || '',
+    Gender: (latestRowData[headerMap['Gender Preference']] || '').toString().trim(),
+    Scent: latestRowData[headerMap['Scent Preference']] || '',
+    DeodorantType: latestRowData[headerMap['Deodorant Type']] || '',
+    BeddingColor: latestRowData[headerMap['Bedding Color']] || '',
+    PillowFirmness: latestRowData[headerMap['Pillow Firmness']] || '',
+    TowelColor: latestRowData[headerMap['Towel Color']] || '',
+    Style: latestRowData[headerMap['Style Preference']] || '',
+    SlidesSize: latestRowData[headerMap['Slides Size']] || '',
+    ShippingPref: latestRowData[headerMap['Shipping Preference (home or college)']] || '',
+    Street: latestRowData[headerMap['Street Address']] || '',
+    City: latestRowData[headerMap['City']] || '',
+    State: latestRowData[headerMap['State']] || '',
+    Zip: latestRowData[headerMap['Zip Code']] || '',
+    DataType: latestRowData[headerMap['data_type']] || 'Live',
+    CohortYear: latestRowData[headerMap['cohort_year']] || new Date().getFullYear(),
+  };
+
+  Logger.log(`Processing submission for: ${studentChoices.StudentName}`);
+
+  // Apply resolver logic to match products
+  const resolvedProducts = applyResolverLogic(studentChoices, logicData);
+
+  // Write results to Resolver sheet
+  writeResolvedProducts(ss, resolvedProducts);
+
+  Logger.log(`✅ Processed ${resolvedProducts.length} product matches for ${studentChoices.StudentName}`);
+}
+
+// ============================================
+// REMOVED: Old Google Forms Trigger
+// ============================================
+// The onFormSubmit(e) function has been removed as it was designed
+// for Google Forms event objects. The new processLatestSubmission()
+// function handles HTML form submissions instead.
+
+// ============================================
+// MENU FUNCTION
+// ============================================
+
+function onOpen() {
+  SpreadsheetApp.getUi()
+  .createMenu('Fulfillment Tools')
+  .addItem('Generate Shopping List', 'generateShoppingList')
+  .addItem('Send Rejection Emails', 'sendRejectionEmails')
+  .addItem('Send Testimonial Invites', 'sendTestimonialInvites')
+  .addSeparator()
+  .addItem('Preview Archive Cohort', 'previewArchiveCohort')
+  .addItem('Archive Cohort', 'archiveCohort')
+  .addToUi();
+}
+
+// ============================================
+// CONFIGURATION CONSTANTS
+// ============================================
+
+const Resolver_Logic = 'Resolver';
+const LOGIC_SHEET_NAME = 'Product_Logic';
+const FORM_RESPONSE_SHEET_NAME = 'Student_Selections';
+
+// Form Headers (from HTML Form submissions)
+const FORM_HEADERS = {
+  'TIMESTAMP': 'Date Submitted',         // ← Now matches doPost header
+  'STUDENT_NAME': 'Student Name',
+  'EMAIL': 'Email Address',
+  'GENDER': 'Gender Preference',
+  'SCENT': 'Scent Preference',
+  'DEODORANT_TYPE': 'Deodorant Type',
+  'BEDDING_COLOR': 'Bedding Color',
+  'PILLOW_FIRMNESS': 'Pillow Firmness',
+  'TOWEL_COLOR': 'Towel Color',
+  'STYLE': 'Style Preference',
+  'SLIDES_SIZE': 'Slides Size',
+  'SHIPPING_PREF': 'Shipping Preference',
+  'STREET': 'Street Address',
+  'CITY': 'City',
+  'STATE': 'State',
+  'ZIP': 'Zip Code'
+};
+
+// Product Logic Sheet Headers (matching actual sheet structure)
+const LOGIC_HEADERS = {
+  // Criteria columns
+  'GENDER_CRIT': 'GENDER',
+  'SCENT_CRIT': 'SCENT',
+  'CHOICE_FIELD': 'CHOICE FIELD',
+  // Output columns
+  'PRODUCT_TYPE': 'PRODUCT TYPE',
+  'RETAILER': 'PRIMARY RETAILER',
+  'SKU': 'PRIMARY SKU',
+  'PRODUCT_NAME': 'PRODUCT',
+  'URL': 'PRIMARY URL',
+  'PRICE': 'PRIMARY PRICE',
+  'QTY': 'QTY PER STUDENT',
+  'EMAIL_OUT': 'Student Email',
+  'NAME_OUT': 'Student Name',
+  'PRODUCT_ID': 'Product ID'
+};
+
+// ============================================
+// DATA LOADING FUNCTIONS
+// ============================================
+
+/**
+ * Loads and processes the Product Logic table into an array of objects
+ * @param {Spreadsheet} ss - The active spreadsheet
+ * @returns {Array<Object>} Array of product objects with all criteria fields
+ */
+function loadLogicTable(ss) {
+  const logicSheet = ss.getSheetByName(LOGIC_SHEET_NAME);
+  if (!logicSheet) {
+    throw new Error(`Sheet '${LOGIC_SHEET_NAME}' not found. Please verify the tab exists.`);
+  }
+
+  const lastRow = logicSheet.getLastRow();
+  if (lastRow < 2) {
+    throw new Error(`Sheet '${LOGIC_SHEET_NAME}' has no data rows.`);
+  }
+
+  // Get all data excluding header row
+  const dataRange = logicSheet.getRange(2, 1, lastRow - 1, logicSheet.getLastColumn());
+  const dataValues = dataRange.getValues();
+  const headers = logicSheet.getRange(1, 1, 1, logicSheet.getLastColumn()).getValues()[0];
+
+  // Create header map for column lookups
+  const headerMap = {};
+  headers.forEach((h, i) => headerMap[h] = i);
+
+  // Validate required headers
+const requiredHeaders = ['PRODUCT TYPE', 'Product ID', 'GENDER', 'SCENT', 'CHOICE FIELD'];
+requiredHeaders.forEach(h => {
+  if (!(h in headerMap)) {
+    throw new Error(`Missing required column in Product_Logic: '${h}'`);
+  }
+});
+
+  // Build product objects
+  const logicMap = [];
+  for (let i = 0; i < dataValues.length; i++) {
+    const row = dataValues[i];
+    const product = {};
+
+    // Map all columns
+    Object.keys(LOGIC_HEADERS).forEach(key => {
+      const colName = LOGIC_HEADERS[key];
+      product[key] = row[headerMap[colName]] || '';
+    });
+
+    // Only include products with a valid Product ID
+    if (product.PRODUCT_ID) {
+      logicMap.push(product);
+    }
+  }
+
+  return logicMap;
+}
+
+/**
+ * Extracts form data from a Google Form submission event
+ * NOTE: This function is kept for backwards compatibility but is no longer used
+ * @param {Object} e - The form submission event
+ * @returns {Object} Standardized student choices object
+ */
+function extractFormData(e) {
+  // This function is deprecated - use processLatestSubmission instead
+  Logger.log('⚠️ extractFormData is deprecated');
+  return null;
+}
+
+// ============================================
+// RESOLVER LOGIC
+// ============================================
+
+/**
+ * Applies matching logic to find products for a student
+ * @param {Object} studentChoices - The student's preferences
+ * @param {Array<Object>} logicData - The product logic table
+ * @returns {Array<Array>} Array of matched product rows
+ */
+function applyResolverLogic(studentChoices, logicData) {
+  Logger.log('\n=== APPLYING RESOLVER LOGIC ===');
+  Logger.log(`Student: ${studentChoices.StudentName}`);
+  Logger.log(`Gender: ${studentChoices.Gender}`);
+  Logger.log(`Scent: ${studentChoices.Scent}`);
+
+  const outputRows = [];
+
+  // Translate gender values for matching (Male→Men, Female→Women)
+  const genderMap = {
+    'Male': 'Men',
+    'Female': 'Women',
+    'Prefer Not to Say (PNS)': 'Unisex',
+    'PNS': 'Unisex'
+  };
+  const normalizedGender = genderMap[studentChoices.Gender] || studentChoices.Gender;
+
+  // Process each product in the logic table
+  for (const product of logicData) {
+    let isMatch = true;
+    const productType = product.PRODUCT_TYPE;
+
+    // GENDER MATCHING
+    if (product.GENDER_CRIT && product.GENDER_CRIT !== 'All') {
+      if (product.GENDER_CRIT !== normalizedGender) {
+        isMatch = false;
+      }
+    }
+
+    // SCENT MATCHING
+    if (isMatch && product.SCENT_CRIT && product.SCENT_CRIT !== 'All') {
+      const isPnsPersonalCare = ['Shaving Cream', 'Deodorant', 'Antiperspirant'].includes(productType) && normalizedGender === 'Unisex';
+
+      // Only run the SCENT match check if it is NOT a PNS/Unisex Personal Care item.
+      if (!isPnsPersonalCare) {
+        if (product.SCENT_CRIT !== studentChoices.Scent) {
+          isMatch = false;
+        }
+      } else {
+        Logger.log(`Bypassing SCENT MATCH for PNS Personal Care: ${product.PRODUCT_NAME}`);
+        // The logic is bypassed, meaning isMatch remains true for this check.
+      }
+    }
+    // CHOICE FIELD MATCHING
+const trimmedChoiceField = (product.CHOICE_FIELD || '').toString().trim();
+if (isMatch && trimmedChoiceField && trimmedChoiceField.toLowerCase() !== 'all') {
+  const choiceValue = getChoiceValueForProduct(product.PRODUCT_TYPE, studentChoices);
+
+  // Skip choice field check if no student preference exists for this product type
+  if (choiceValue === '') {
+    Logger.log(`No student choice field for ${product.PRODUCT_TYPE}, skipping choice field check`);
+  } else {
+    Logger.log(`CHOICE_FIELD: '${trimmedChoiceField}' vs Student Value: '${(choiceValue || '').toString().trim()}'`);
+    if (trimmedChoiceField.toLowerCase() !== (choiceValue || '').toString().trim().toLowerCase()) {
+      isMatch = false;
+    }
+  }
+}
+
+    // If all criteria match, add to output
+    if (isMatch) {
+      // === BEGIN MOD v2.1 - Resolver tag inheritance added Nov 3, 2025 ===
+const outputRow = [
+Utilities.formatDate(new Date(String(studentChoices.Timestamp)), Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm'),
+  studentChoices.Email,
+  studentChoices.StudentName,
+  product.PRODUCT_TYPE,
+  product.RETAILER,
+  product.SKU,
+  product.PRODUCT_NAME,
+  product.URL,
+  product.PRICE,
+  product.QTY,
+  product.PRODUCT_ID,
+  studentChoices.DataType,
+  studentChoices.CohortYear,
+  false
+];
+// === END MOD v2.1 ===
+
+      outputRows.push(outputRow);
+      Logger.log(`✅ MATCH: ${product.PRODUCT_NAME} (${product.PRODUCT_ID})`);
+    }
+  }
+
+  // Add blank separator row after each student
+  outputRows.push(Array(14).fill(''));
+
+  Logger.log(`Total matches for ${studentChoices.StudentName}: ${outputRows.length - 1}`);
+  return outputRows;
+}
+
+/**
+ * Gets the appropriate choice value based on product type
+ * @param {string} productType - The type of product
+ * @param {Object} studentChoices - Student's preferences
+ * @returns {string} The relevant choice value
+ */
+function getChoiceValueForProduct(productType, studentChoices) {
+  switch (productType) {
+    case 'Sheet Set':
+    case 'Duvet Cover':
+      return studentChoices.BeddingColor;
+    case 'Pillow':
+      return studentChoices.PillowFirmness;
+    case 'Shampoo':
+    case 'Conditioner':
+    case 'Shampoo & Conditioner Set':
+      return studentChoices.Scent;
+    case 'Towel Set':
+      return studentChoices.TowelColor;
+    case 'Slides':
+      return studentChoices.SlidesSize;
+    case 'Deodorant':
+    case 'Antiperspirant':
+      return studentChoices.DeodorantType;
+    case 'Shaving Cream':
+  return ''; // No student preference field exists for shaving cream
+    case 'Laundry Basket':
+    case 'Shower Caddy':
+    case 'Storage Bins':
+    case 'Hangers':
+    case 'Desk Organizer':
+    case 'Toiletry Bag':
+      return studentChoices.Style;
+    default:
+      return '';
+  }
+}
+
+// ============================================
+// OUTPUT FUNCTIONS
+// ============================================
+
+/**
+ * Writes resolved products to the Resolver sheet
+ * @param {Spreadsheet} ss - The active spreadsheet
+ * @param {Array<Array>} resolvedProducts - Array of product rows to write
+ */
+function writeResolvedProducts(ss, resolvedProducts) {
+  const resolverSheet = ss.getSheetByName(Resolver_Logic) || ss.insertSheet(Resolver_Logic);
+
+  // Set up headers if this is a new sheet
+  if (resolverSheet.getLastRow() === 0) {
+    // === BEGIN MOD v2.1 - Resolver headers updated Nov 3, 2025 ===
+const headers = [
+  'Timestamp',
+  'Email',
+  'Student Name',
+  'Product Type',
+  'Retailer',
+  'SKU',
+  'Product Name',
+  'URL',
+  'Price',
+  'Qty',
+  'Product ID',
+  'data_type',
+  'cohort_year',
+  'shopping_list_generated'
+];
+// === END MOD v2.1 ===
+    resolverSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    resolverSheet.getRange(1, 1, 1, headers.length)
+      .setFontWeight('bold')
+      .setBackground('#4285f4')
+      .setFontColor('#ffffff');
+    resolverSheet.setFrozenRows(1);
+  }
+
+  // Append the resolved products
+  if (resolvedProducts.length > 0) {
+    const startRow = resolverSheet.getLastRow() + 1;
+    resolverSheet.getRange(startRow, 1, resolvedProducts.length, resolvedProducts[0].length)
+      .setValues(resolvedProducts);
+    Logger.log(`✅ Wrote ${resolvedProducts.length} rows to Resolver sheet`);
+  }
+}
+
+// ============================================
+// SHOPPING LIST GENERATOR
+// ============================================
+// (Rest of the code remains EXACTLY the same - lines 732-1090)
+// Including:
+// - generateShoppingList()
+// - All helper functions
+// - buildProductLookupKey()
+// - buildConditionalPreferences()
+// - buildProductMap()
+// - buildStudentMap()
+// - loadSheetData()
+// - getHeaderMap()
+
+// ============================================
+// SHOPPING LIST GENERATOR - CORRECTED
+// ============================================
+// Replace lines 500-830 in your script with this
+
+const OUTPUT_TAB_NAME = 'Shopping_List';
+const LOG_TAB_NAME = 'Errors';
+
+function generateShoppingList() {
+  Logger.log('=== STARTING SHOPPING LIST GENERATION ===');
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+  // Load data
+  const resolverData = loadSheetData(ss, 'Resolver');
+  const productLogicData = loadSheetData(ss, 'Product_Logic');
+  const studentData = loadSheetData(ss, 'Student_Selections');
+
+// === BEGIN PHASE 5 - Grant Recipients Approval Filter Nov 17, 2025 ===
+  // Load Grant_Recipients to verify document approval status
+  const grantRecipientsSheet = ss.getSheetByName('Grant_Recipients');
+  if (!grantRecipientsSheet) {
+    SpreadsheetApp.getUi().alert('Error: Grant_Recipients sheet not found. Shopping list cannot be generated without approval verification.');
+    return;
+  }
+
+  const grantRecipientsData = grantRecipientsSheet.getDataRange().getValues();
+
+  // Build approval lookup map: email -> {housingStatus, acceptanceStatus}
+  const approvalMap = {};
+  for (let i = 1; i < grantRecipientsData.length; i++) {
+    const email = grantRecipientsData[i][2]; // Column C
+    const housingStatus = grantRecipientsData[i][5]; // Column F
+    const acceptanceStatus = grantRecipientsData[i][7]; // Column H
+
+    if (email) {
+      approvalMap[email.toString().toLowerCase()] = {
+        housing: housingStatus,
+        acceptance: acceptanceStatus,
+        approved: housingStatus === 'Approved' && acceptanceStatus === 'Approved'
+      };
+    }
+  }
+
+  Logger.log(`Loaded approval status for ${Object.keys(approvalMap).length} students from Grant_Recipients`);
+
+  // Initialize tracking for skipped students
+  const skippedStudents = {
+    notFound: [],
+    housingNotApproved: [],
+    acceptanceNotApproved: [],
+    bothNotApproved: []
+  };
+  // === END PHASE 5 ===
+
+// === BEGIN MOD v2.1 - Filter Resolver rows Nov 3, 2025 ===
+const currentYear = Math.max(...studentData.map(row => {
+  const year = parseInt(row[getHeaderMap(ss.getSheetByName('Student_Selections'))['cohort_year']]);
+  return isNaN(year) ? 0 : year;
+}));
+
+const resolverHeaderMap = getHeaderMap(ss.getSheetByName('Resolver'));
+const filteredResolverData = [];
+const resolverRowNumbers = []; // Track actual sheet row numbers
+
+resolverData.forEach((row, i) => {
+  const dataType = row[resolverHeaderMap['data_type']];
+  const cohortYear = parseInt(row[resolverHeaderMap['cohort_year']]);
+  const generatedFlag = row[resolverHeaderMap['shopping_list_generated']];
+
+  if (dataType === 'Live' && cohortYear === currentYear && generatedFlag !== true) {
+    filteredResolverData.push(row);
+    resolverRowNumbers.push(i + 2); // +2 accounts for header row and 0-based index
+  }
+});
+// === END MOD v2.1 ===
+
+
+  if (resolverData.length === 0) {
+    SpreadsheetApp.getUi().alert('No data found in Resolver tab. Please run the resolver first.');
+    return;
+  }
+
+  // Build lookup maps
+  const productMap = buildProductMap(productLogicData);
+  const studentMap = buildStudentMap(studentData);
+
+  Logger.log(`Loaded ${Object.keys(productMap).length} products from Product_Logic`);
+  Logger.log(`Loaded ${Object.keys(studentMap).length} students from Student Selections`);
+
+  // Process resolver rows
+  const outputRows = [];
+  const errors = [];
+  let rowNum = 2;
+
+  for (const row of filteredResolverData) {
+    const studentName = row[2];
+    const studentEmail = row[1];     // ← Added email from Resolver
+
+// === BEGIN PHASE 5 - Verify Document Approval Nov 17, 2025 ===
+    // Check if student has approved documents
+    const approval = approvalMap[studentEmail.toLowerCase()];
+
+    if (!approval) {
+      Logger.log(`⚠️ Student ${studentName} (${studentEmail}) not found in Grant_Recipients - SKIPPED`);
+      skippedStudents.notFound.push(studentName);
+      rowNum++;
+      continue;
+    }
+
+    if (!approval.approved) {
+      // Track WHY they were skipped
+      const housingApproved = approval.housing === 'Approved';
+      const acceptanceApproved = approval.acceptance === 'Approved';
+
+      if (!housingApproved && !acceptanceApproved) {
+        skippedStudents.bothNotApproved.push(studentName);
+      } else if (!housingApproved) {
+        skippedStudents.housingNotApproved.push(studentName);
+      } else {
+        skippedStudents.acceptanceNotApproved.push(studentName);
+      }
+
+      Logger.log(`⚠️ Student ${studentName} (${studentEmail}) documents not approved - SKIPPED (Housing: ${approval.housing}, Acceptance: ${approval.acceptance})`);
+      rowNum++;
+      continue;
+    }
+
+    Logger.log(`✓ Student ${studentName} (${studentEmail}) verified - documents approved`);
+    // === END PHASE 5 ===
+
+    const productId = row[10];
+
+    // Skip blank separator rows
+    if (!studentName || !productId) {
+      rowNum++;
+      continue;
+    }
+
+    // Look up student and product
+    const student = studentMap[studentName];
+    const product = productMap[productId];
+
+    if (!student) {
+      errors.push([rowNum, studentName, productId, 'Student not found in Student Selections']);
+      rowNum++;
+      continue;
+    }
+
+    if (!product) {
+      errors.push([rowNum, studentName, productId, 'Product not found in Product_Logic']);
+      rowNum++;
+      continue;
+    }
+
+    // Build output row
+    const prefs = buildConditionalPreferences(product.ProductType, student);
+    const productLookup = buildProductLookupKey(product.ProductType, student, product);
+
+    // Calculate total cost - IMPROVED PRICE PARSING
+    const qty = parseFloat(product.Qty) || 1;
+
+    // Handle price - remove $ and commas if present
+    let unitPrice = 0;
+    if (product.Price) {
+      const priceStr = product.Price.toString().replace(/[$,]/g, '');
+      unitPrice = parseFloat(priceStr) || 0;
+    }
+
+    const totalCost = qty * unitPrice;
+
+    // Log if price is still 0 for debugging
+    if (unitPrice === 0) {
+      Logger.log(`⚠️ Warning: Price is 0 for ${product.ProductName} (${productId})`);
+      Logger.log(`Raw price value: ${product.Price}`);
+    }
+
+    outputRows.push([
+      // GROUP 1: STUDENT INFO (CORRECTED ORDER)
+      studentName,
+      studentEmail,              // ← ADDED: Student Email
+      student.Street1,           // Maps to "Street Address" (not "Street Address 1")
+      student.Street2,
+      student.City,
+      student.State,
+      student.Zip,               // Maps to "Zip Code"
+      student.ShippingPref,      // Maps to "Shipping Pref"
+
+      // GROUP 2: PRODUCT SELECTION
+      productLookup,
+
+      // GROUP 3: PRODUCT DETAILS
+      product.ProductType,
+      product.Brand || '',
+      product.ProductName,
+      product.SKU || productId, // This is the SKU
+      product.Retailer,
+      product.URL,
+
+      // GROUP 4: PRICING
+      qty,
+      unitPrice,                 // Now properly parsed
+      totalCost,                 // Now correctly calculated
+
+      // GROUP 5: STUDENT PREFERENCES
+      prefs.gender,
+      prefs.scent,
+      prefs.deodorantType,
+      prefs.style,
+      prefs.beddingColor,
+      prefs.pillowFirmness,
+      prefs.towelColor,
+      prefs.slidesSize,
+      row[resolverHeaderMap['data_type']],
+      row[resolverHeaderMap['cohort_year']]
+    ]);
+
+    rowNum++;
+  }
+
+  // === BEGIN PHASE 5 - Report Filtering Results Nov 17, 2025 ===
+  const totalProcessed = filteredResolverData.length;
+  const totalIncluded = outputRows.length;
+  const totalSkipped = totalProcessed - totalIncluded;
+
+  Logger.log('=== APPROVAL FILTER RESULTS ===');
+  Logger.log(`Total students processed: ${totalProcessed}`);
+  Logger.log(`Students included (approved): ${totalIncluded}`);
+  Logger.log(`Students skipped (not approved): ${totalSkipped}`);
+
+  // Build summary alert message
+  if (totalSkipped > 0) {
+    let alertMessage = `Shopping List Generated\n\n`;
+    alertMessage += `✓ ${totalIncluded} students included (documents approved)\n`;
+    alertMessage += `⚠️ ${totalSkipped} students skipped:\n\n`;
+
+    if (skippedStudents.notFound.length > 0) {
+      alertMessage += `• Not found in Grant_Recipients: ${skippedStudents.notFound.length}\n`;
+      alertMessage += `  ${skippedStudents.notFound.join(', ')}\n\n`;
+    }
+
+    if (skippedStudents.bothNotApproved.length > 0) {
+      alertMessage += `• Both documents not approved: ${skippedStudents.bothNotApproved.length}\n`;
+      alertMessage += `  ${skippedStudents.bothNotApproved.join(', ')}\n\n`;
+    }
+
+    if (skippedStudents.housingNotApproved.length > 0) {
+      alertMessage += `• Housing not approved: ${skippedStudents.housingNotApproved.length}\n`;
+      alertMessage += `  ${skippedStudents.housingNotApproved.join(', ')}\n\n`;
+    }
+
+    if (skippedStudents.acceptanceNotApproved.length > 0) {
+      alertMessage += `• Acceptance not approved: ${skippedStudents.acceptanceNotApproved.length}\n`;
+      alertMessage += `  ${skippedStudents.acceptanceNotApproved.join(', ')}\n\n`;
+    }
+
+    SpreadsheetApp.getUi().alert('Shopping List - Approval Filter Applied', alertMessage, SpreadsheetApp.getUi().ButtonSet.OK);
+  } else {
+    SpreadsheetApp.getUi().alert('Shopping List Generated', `All ${totalIncluded} students have approved documents and were included in the shopping list.`, SpreadsheetApp.getUi().ButtonSet.OK);
+  }
+  // === END PHASE 5 ===
+
+  // Write to output sheet
+  const outputSheet = ss.getSheetByName(OUTPUT_TAB_NAME) || ss.insertSheet(OUTPUT_TAB_NAME);
+
+  // Set up headers if needed - CORRECTED TO MATCH APPROVED VERSION
+  if (outputSheet.getLastRow() < 1) {
+    const headers = [
+      // GROUP 1: STUDENT INFO
+      'Student Name',
+      'Student Email',           // ← ADDED
+      'Street Address',          // ← CORRECTED: Was "Street Address 1"
+      'Street Address 2',
+      'City',
+      'State',
+      'Zip Code',                // ← CORRECTED: Was "Zip"
+      'Shipping Pref',           // ← CORRECTED: Was "Shipping Preference"
+
+      // GROUP 2: PRODUCT SELECTION
+      'Product Selection',
+
+      // GROUP 3: PRODUCT DETAILS
+      'Product Type',
+      'Brand',
+      'Product Name',
+      'SKU',
+      'Retailer',
+      'URL',
+
+      // GROUP 4: PRICING
+      'Quantity',
+      'Unit Price',
+      'Total Cost',
+
+      // GROUP 5: STUDENT PREFERENCES
+      'Gender',
+      'Scent',
+      'Deodorant Type',
+      'Style',
+      'Bedding Color',
+      'Pillow Firmness',
+      'Towel Color',
+      'Slides Size'
+    ];
+
+    outputSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+
+    // Format headers
+    const headerRange = outputSheet.getRange(1, 1, 1, headers.length);
+    headerRange.setFontWeight('bold');
+    headerRange.setBackground('#4285f4');
+    headerRange.setFontColor('#ffffff');
+  } else {
+    Logger.log('Headers already exist - preserving your formatting');
+  }
+
+  // Write data
+  if (outputRows.length > 0) {
+    const startRow = 2;
+    outputSheet.getRange(startRow, 1, outputRows.length, outputRows[0].length).setValues(outputRows);
+    Logger.log(`Wrote ${outputRows.length} rows to Shopping_List`);
+  }
+// === BEGIN MOD v2.1 - Mark items as generated Nov 3, 2025 ===
+  const resolverSheet = ss.getSheetByName('Resolver');
+  const generatedColIndex = resolverHeaderMap['shopping_list_generated'];
+
+  resolverRowNumbers.forEach(actualRowNum => {
+    resolverSheet.getRange(actualRowNum, generatedColIndex + 1).setValue(true);
+  });
+  Logger.log(`✅ Marked ${resolverRowNumbers.length} Resolver rows as generated`);
+// === END MOD v2.1 ===
+
+// Write errors to log
+  if (errors.length > 0) {
+    const logSheet = ss.getSheetByName(LOG_TAB_NAME) || ss.insertSheet(LOG_TAB_NAME);
+    if (logSheet.getLastRow() < 1) {
+      logSheet.getRange(1, 1, 1, 4).setValues([['Row', 'Student', 'SKU', 'Error']]);
+    }
+    logSheet.getRange(logSheet.getLastRow() + 1, 1, errors.length, errors[0].length).setValues(errors);
+    Logger.log(`Logged ${errors.length} errors`);
+  }
+
+  Logger.log('=== SHOPPING LIST GENERATION COMPLETE ===');
+
+  // Show completion message
+  SpreadsheetApp.getUi().alert(
+    'Shopping List Generated',
+    `Successfully generated ${outputRows.length} line items.\n\n` +
+    `Errors: ${errors.length}\n\n` +
+    (errors.length > 0 ? `Check the '${LOG_TAB_NAME}' tab for error details.` : 'No errors found!'),
+    SpreadsheetApp.getUi().ButtonSet.OK
+  );
+}
+
+// === BEGIN MOD v2.1 - Preview Archive Cohort added Nov 3, 2025 ===
+function previewArchiveCohort() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+  // Get the current year from Student Selections
+  const selectionsSheet = ss.getSheetByName('Student_Selections');
+  if (!selectionsSheet || selectionsSheet.getLastRow() < 2) {
+    SpreadsheetApp.getUi().alert('No data found in Student Selections to archive.');
+    return;
+  }
+
+  const selectionsData = selectionsSheet.getDataRange().getValues();
+  const selectionsMap = getHeaderMap(selectionsSheet);
+  const timestampIndex = selectionsMap['Timestamp'];
+  const cohortYearIndex = selectionsMap['cohort_year'];
+const validYears = selectionsData.slice(1).map(row => {
+    const year = parseInt(row[cohortYearIndex]);
+    return isNaN(year) ? 0 : year;
+  });
+  const currentYear = Math.max(...validYears);
+
+  if (currentYear === 0) {
+    SpreadsheetApp.getUi().alert('Error: Could not determine current cohort year from data. Archive cancelled.');
+    return;
+  }
+  // Count rows that would be archived from each tab
+  let selectionsCount = 0;
+  let resolverCount = 0;
+  let shoppingCount = 0;
+
+  // Count Student Selections rows
+ selectionsData.slice(1).forEach(row => {
+  if (parseInt(row[cohortYearIndex]) === currentYear) {
+    const timestampIndex = selectionsMap['Timestamp'];
+    row[timestampIndex] = Utilities.formatDate(new Date(row[timestampIndex]), Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm');
+    selectionsCount++;
+  }
+});
+
+  // Count Resolver rows
+  const resolverSheet = ss.getSheetByName('Resolver');
+  if (resolverSheet && resolverSheet.getLastRow() > 1) {
+    const resolverData = resolverSheet.getDataRange().getValues();
+    const resolverMap = getHeaderMap(resolverSheet);
+    const resolverYearIndex = resolverMap['cohort_year'];
+    resolverData.slice(1).forEach(row => {
+      if (parseInt(row[resolverYearIndex]) === currentYear) {
+        resolverCount++;
+      }
+    });
+  }
+
+  // Count Shopping List rows
+  const shoppingSheet = ss.getSheetByName('Shopping_List');
+  if (shoppingSheet && shoppingSheet.getLastRow() > 1) {
+    const shoppingData = shoppingSheet.getDataRange().getValues();
+    const shoppingMap = getHeaderMap(shoppingSheet);
+    const shoppingYearIndex = shoppingMap['cohort_year'];
+    shoppingData.slice(1).forEach(row => {
+      if (parseInt(row[shoppingYearIndex]) === currentYear) {
+        shoppingCount++;
+      }
+    });
+  }
+
+  const totalRows = selectionsCount + resolverCount + shoppingCount;
+
+  SpreadsheetApp.getUi().alert(
+    'Archive Preview',
+    `The following rows from cohort ${currentYear} would be archived:\n\n` +
+    `• Student Selections: ${selectionsCount} rows\n` +
+    `• Resolver: ${resolverCount} rows\n` +
+    `• Shopping_List: ${shoppingCount} rows\n\n` +
+    `Total: ${totalRows} rows\n\n` +
+    `These would be moved to the respective Archive tabs and the active tabs would be cleared.`,
+    SpreadsheetApp.getUi().ButtonSet.OK
+  );
+}
+// === END MOD v2.1 ===
+
+// === BEGIN MOD v2.1 - Archive Cohort added Nov 3, 2025 ===
+function archiveCohort() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+
+  // Get current year
+  const selectionsSheet = ss.getSheetByName('Student_Selections');
+  if (!selectionsSheet || selectionsSheet.getLastRow() < 2) {
+    SpreadsheetApp.getUi().alert('No data found in Student Selections to archive.');
+    return;
+  }
+
+  const selectionsData = selectionsSheet.getDataRange().getValues();
+  const selectionsMap = getHeaderMap(selectionsSheet);
+  const cohortYearIndex = selectionsMap['cohort_year'];
+  const currentYear = Math.max(...selectionsData.slice(1).map(row => parseInt(row[cohortYearIndex])));
+  const studentsToArchive = selectionsData.slice(1).filter(row => parseInt(row[cohortYearIndex]) === currentYear).length;
+
+  // Confirm with user
+  const ui = SpreadsheetApp.getUi();
+const response = ui.alert(
+  `Archive Confirmation`,
+  `You are about to archive ${studentsToArchive} students from cohort ${currentYear}.\n\n` +
+  `This will move all matching rows from Student_Selections, Resolver, and Shopping_List to their respective archive tabs and clear them from the active tabs.\n\n` +
+  `Do you want to proceed?`,
+  ui.ButtonSet.YES_NO
+);
+
+if (response !== ui.Button.YES) {
+  ui.alert('Archive cancelled.');
+  return;
+}
+
+  // Process Student Selections Archive
+  const selectionsArchiveSheet = ss.getSheetByName('Student_Selections_Archive') || ss.insertSheet('Student_Selections_Archive');
+  if (selectionsArchiveSheet.getLastRow() === 0) {
+    // Copy headers from Student Selections
+    const headers = selectionsSheet.getRange(1, 1, 1, selectionsSheet.getLastColumn()).getValues()[0];
+    selectionsArchiveSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+  }
+
+  let selectionsArchivedCount = 0;
+let resolverArchivedCount = 0;
+let shoppingArchivedCount = 0;
+const selectionsRowsToArchive = [];
+
+// 1. Process Student Selections Archive
+selectionsData.slice(1).forEach(row => {
+  if (parseInt(row[cohortYearIndex]) === currentYear) {
+    selectionsRowsToArchive.push(row);
+    selectionsArchivedCount++;
+  }
+});
+
+if (selectionsRowsToArchive.length > 0) {
+    const startRow = selectionsArchiveSheet.getLastRow() + 1;
+    selectionsArchiveSheet.getRange(startRow, 1, selectionsRowsToArchive.length, selectionsRowsToArchive[0].length).setValues(selectionsRowsToArchive);
+}
+
+// 2. Process Resolver Archive
+const resolverSheet = ss.getSheetByName('Resolver');
+if (resolverSheet && resolverSheet.getLastRow() > 1) {
+    const resolverArchiveSheet = ss.getSheetByName('Resolver_Archive') || ss.insertSheet('Resolver_Archive');
+if (resolverArchiveSheet.getLastRow() === 0) {
+      const headers = resolverSheet.getRange(1, 1, 1, resolverSheet.getLastColumn()).getValues()[0];
+resolverArchiveSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    }
+
+    const resolverData = resolverSheet.getDataRange().getValues();
+    const resolverMap = getHeaderMap(resolverSheet);
+const resolverYearIndex = resolverMap['cohort_year'];
+
+    const resolverRowsToArchive = [];
+    resolverData.slice(1).forEach(row => {
+      if (parseInt(row[resolverYearIndex]) === currentYear) {
+        resolverRowsToArchive.push(row);
+        resolverArchivedCount++;
+      }
+    });
+if (resolverRowsToArchive.length > 0) {
+      const startRow = resolverArchiveSheet.getLastRow() + 1;
+      resolverArchiveSheet.getRange(startRow, 1, resolverRowsToArchive.length, resolverRowsToArchive[0].length).setValues(resolverRowsToArchive);
+    }
+  }
+
+// 3. Process Shopping List Archive
+const shoppingSheet = ss.getSheetByName('Shopping_List');
+if (shoppingSheet && shoppingSheet.getLastRow() > 1) {
+    const shoppingArchiveSheet = ss.getSheetByName('Shopping_List_Archive') || ss.insertSheet('Shopping_List_Archive');
+if (shoppingArchiveSheet.getLastRow() === 0) {
+      const headers = shoppingSheet.getRange(1, 1, 1, shoppingSheet.getLastColumn()).getValues()[0];
+shoppingArchiveSheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    }
+
+    const shoppingData = shoppingSheet.getDataRange().getValues();
+    const shoppingMap = getHeaderMap(shoppingSheet);
+const shoppingYearIndex = shoppingMap['cohort_year'];
+
+  const shoppingRowsToArchive = [];
+    shoppingData.slice(1).forEach(row => {
+      if (parseInt(row[shoppingYearIndex]) === currentYear) {
+        shoppingRowsToArchive.push(row);
+        shoppingArchivedCount++;
+      }
+    });
+if (shoppingRowsToArchive.length > 0) {
+      const startRow = shoppingArchiveSheet.getLastRow() + 1;
+      shoppingArchiveSheet.getRange(startRow, 1, shoppingRowsToArchive.length, shoppingRowsToArchive[0].length).setValues(shoppingRowsToArchive);
+    }
+  }
+
+// 4. Clear active tabs (delete all data rows, keep headers)
+// Rows were counted above, so we can now safely clear the active tabs.
+if (selectionsSheet.getLastRow() > 1) {
+    selectionsSheet.deleteRows(2, selectionsSheet.getLastRow() - 1);
+}
+if (resolverSheet && resolverSheet.getLastRow() > 1) {
+    resolverSheet.deleteRows(2, resolverSheet.getLastRow() - 1);
+}
+if (shoppingSheet && shoppingSheet.getLastRow() > 1) {
+    shoppingSheet.deleteRows(2, shoppingSheet.getLastRow() - 1);
+}
+
+const totalArchived = selectionsArchivedCount + resolverArchivedCount + shoppingArchivedCount;
+
+ui.alert(
+    'Archive Complete',
+    `Successfully archived cohort ${currentYear}. Total rows moved: ${totalArchived}.\n\n` +
+    `• Student Selections: ${selectionsArchivedCount} rows\n` +
+    `• Resolver: ${resolverArchivedCount} rows\n` +
+    `• Shopping_List: ${shoppingArchivedCount} rows\n\n` +
+    `Active tabs have been cleared and are ready for the next cohort.`,
+    ui.ButtonSet.OK
+  );
+}
+// === END MOD v2.1 ===
+
+// ============================================
+// HELPER FUNCTIONS
+// ============================================
+
+function buildProductLookupKey(productType, student, product) {
+  const parts = [];
+
+  const genderMap = {
+    'Male': "Men's",
+    'Female': "Women's",
+    'Prefer Not to Say (PNS)': 'Unisex',
+    'PNS': 'Unisex'
+  };
+
+  if (student.Gender && ['Razor Handle', 'Razor Refills', 'Slides', 'Deodorant', 'Antiperspirant'].includes(productType)) {
+    const genderPrefix = genderMap[student.Gender] || student.Gender;
+    if (genderPrefix !== 'Unisex') {
+      parts.push(genderPrefix);
+    } else {
+      parts.push('Unisex');
+    }
+  }
+
+  if (productType === 'Sheet Set' || productType === 'Duvet Cover') {
+    if (student.Color) parts.push(student.Color);
+  } else if (productType === 'Pillow') {
+    if (student.Firmness) parts.push(student.Firmness);
+  } else if (productType === 'Towel Set') {
+    if (student.TowelColor) parts.push(student.TowelColor);
+  } else if (productType === 'Slides') {
+    if (student.SlidesSize) parts.push(student.SlidesSize);
+  } else if (['Deodorant', 'Antiperspirant'].includes(productType)) {
+    if (student.Scent) parts.push(student.Scent);
+  } else if (['Laundry Basket', 'Shower Caddy', 'Storage Bins', 'Hangers', 'Desk Organizer', 'Toiletry Bag'].includes(productType)) {
+    if (student.Style) parts.push(student.Style);
+  }
+
+  parts.push(productType);
+
+  return parts.join(' ');
+}
+
+function buildConditionalPreferences(productType, student) {
+  const prefs = {
+    gender: '',
+    scent: '',
+    deodorantType: '',
+    style: '',
+    beddingColor: '',
+    pillowFirmness: '',
+    towelColor: '',
+    slidesSize: ''
+  };
+
+  if (['Razor Handle', 'Razor Refills', 'Slides', 'Deodorant', 'Antiperspirant'].includes(productType)) {
+    prefs.gender = student.Gender || '';
+  }
+
+  if (['Deodorant', 'Antiperspirant', 'Body Wash', 'Shampoo & Conditioner Set', 'Lotion'].includes(productType)) {
+    prefs.scent = student.Scent || '';
+  }
+
+  if (['Deodorant', 'Antiperspirant'].includes(productType)) {
+    prefs.deodorantType = student.DeodorantType || '';
+  }
+
+  if (['Laundry Basket', 'Shower Caddy', 'Storage Bins', 'Hangers', 'Desk Organizer', 'Toiletry Bag'].includes(productType)) {
+    prefs.style = student.Style || '';
+  }
+
+  if (['Sheet Set', 'Duvet Cover'].includes(productType)) {
+    prefs.beddingColor = student.Color || '';
+  }
+
+  if (productType === 'Pillow') {
+    prefs.pillowFirmness = student.Firmness || '';
+  }
+
+  if (productType === 'Towel Set') {
+    prefs.towelColor = student.TowelColor || '';
+  }
+
+  if (productType === 'Slides') {
+    prefs.slidesSize = student.SlidesSize || '';
+  }
+
+  return prefs;
+}
+
+function buildProductMap(data) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Product_Logic');
+  const headerMap = getHeaderMap(sheet);
+  const map = {};
+
+  data.forEach(row => {
+    const productId = row[headerMap['Product ID']];
+    if (productId) {
+      map[productId] = {
+        ProductType: row[headerMap['PRODUCT TYPE']],
+        Brand: row[headerMap['PRIMARY BRAND']],
+        ProductName: row[headerMap['PRODUCT']],
+        SKU: row[headerMap['PRIMARY SKU']],
+        Price: row[headerMap['PRIMARY PRICE']],        // Will be cleaned in generateShoppingList
+        Qty: row[headerMap['QTY PER STUDENT']],
+        Retailer: row[headerMap['PRIMARY RETAILER']],
+        URL: row[headerMap['PRIMARY URL']],
+        Gender: row[headerMap['GENDER']],
+        Scent: row[headerMap['SCENT']],
+        ChoiceField: row[headerMap['CHOICE FIELD']]
+      };
+    }
+  });
+
+  return map;
+}
+
+function buildStudentMap(data) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Student_Selections');
+  const headerMap = getHeaderMap(sheet);
+  const map = {};
+
+  data.forEach(row => {
+    const name = row[headerMap['Student Name']];
+    if (name) {
+      map[name] = {
+        Email: row[headerMap['Email Address']],       // ← ADDED
+        Street1: row[headerMap['Street Address']],
+        Street2: row[headerMap['Street Address 2']] || '',
+        City: row[headerMap['City']],
+        State: row[headerMap['State']],
+        Zip: row[headerMap['Zip Code']],
+        ShippingPref: row[headerMap['Shipping Preference (home or college)']] || row[headerMap['Shipping Preference']] || '',
+        Gender: row[headerMap['Gender Preference']],
+        Scent: row[headerMap['Scent Preference']],
+        DeodorantType: row[headerMap['Deodorant Type']],
+        Style: row[headerMap['Style Preference']],
+        Color: row[headerMap['Bedding Color']],
+        Firmness: row[headerMap['Pillow Firmness']],
+        TowelColor: row[headerMap['Towel Color']],
+        SlidesSize: row[headerMap['Slides Size']]
+      };
+    }
+  });
+
+  return map;
+}
+
+function loadSheetData(ss, tabName) {
+  const sheet = ss.getSheetByName(tabName);
+  if (!sheet) {
+    throw new Error(`Sheet '${tabName}' not found`);
+  }
+
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    Logger.log(`Warning: Sheet '${tabName}' has no data rows`);
+    return [];
+  }
+
+  const numRows = lastRow - 1;
+  const numCols = sheet.getLastColumn();
+  return sheet.getRange(2, 1, numRows, numCols).getValues();
+}
+
+function getHeaderMap(sheet) {
+  const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+  const map = {};
+  headers.forEach((header, index) => {
+    map[header.trim()] = index;
+  });
+  return map;
+}
+
+// ============================================
+// TEST FUNCTIONS (Keep for debugging)
+// ============================================
+
+function debugProductLogicForGurn() {
+  // Your existing debug function - unchanged
+  Logger.log('Debug function preserved');
+}
+// ============================================
+// TEST: Email Validation - Added Nov 15, 2025
+// ============================================
+
+function testCheckStudentStatus() {
+  // Test with Andrew Santino's email
+  const testEmail = 'elilavois@gmail.com';
+  const result = checkStudentStatus(testEmail);
+
+  Logger.log('=== EMAIL VALIDATION TEST ===');
+  Logger.log('Testing email: ' + testEmail);
+  Logger.log('Result:');
+  Logger.log(JSON.stringify(result, null, 2));
+  Logger.log('===========================');
+}
+
+function testDoPostRouting() {
+  // Test the doPost routing with checkStudentStatus action
+  const mockRequest = {
+    postData: {
+      contents: JSON.stringify({
+        action: 'checkStudentStatus',
+        email: 'elilavois@gmail.com'
+      })
+    }
+  };
+
+  const result = doPost(mockRequest);
+
+  Logger.log('=== DOPOST ROUTING TEST ===');
+  Logger.log('Response:');
+  Logger.log(result.getContent());
+  Logger.log('===========================');
+}
+// ============================================
+// TEST: Document Upload - Added Nov 16, 2025
+// ============================================
+
+function testUploadDocuments() {
+  // This test uses a tiny valid base64-encoded 1x1 pixel PNG image
+  // so we can verify the upload process works without large files
+
+  const testEmail = 'elilavois@gmail.com';
+  const testApplicationId = 'CR_1758657496058_8l0scy';
+
+  // Tiny 1x1 pixel PNG (68 bytes) - valid base64
+  const tinyPngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+  const housingFile = {
+    name: 'test_housing.png',
+    data: tinyPngBase64
+  };
+
+  const acceptanceFile = {
+    name: 'test_acceptance.png',
+    data: tinyPngBase64
+  };
+
+  Logger.log('=== TESTING UPLOAD DOCUMENTS ===');
+  Logger.log('Test email: ' + testEmail);
+  Logger.log('Test application ID: ' + testApplicationId);
+
+  const result = uploadDocuments(testEmail, testApplicationId, housingFile, acceptanceFile);
+
+  Logger.log('=== TEST RESULT ===');
+  Logger.log(JSON.stringify(result, null, 2));
+  Logger.log('==================');
+
+  // Also test through doPost to verify the routing
+  Logger.log('=== TESTING DOPOST ROUTING ===');
+  const mockRequest = {
+    postData: {
+      contents: JSON.stringify({
+        action: 'uploadDocuments',
+        email: testEmail,
+        applicationId: testApplicationId,
+        housingFile: housingFile,
+        acceptanceFile: acceptanceFile
+      })
+    }
+  };
+
+  const doPostResult = doPost(mockRequest);
+  Logger.log('doPost response:');
+  Logger.log(doPostResult.getContent());
+  Logger.log('=============================');
+}
+
+function testUploadWithMissingData() {
+  // Test error handling when data is missing
+  Logger.log('=== TESTING ERROR HANDLING ===');
+
+  const testEmail = 'elilavois@gmail.com';
+  const testApplicationId = 'CR_1758657496058_8l0scy';
+
+  // Test with null housingFile
+  Logger.log('Test 1: Null housing file');
+  let result = uploadDocuments(testEmail, testApplicationId, null, {name: 'test.png', data: 'abc'});
+  Logger.log('Result: ' + JSON.stringify(result));
+
+  // Test with missing data property
+  Logger.log('Test 2: Missing data property');
+  result = uploadDocuments(testEmail, testApplicationId, {name: 'test.png'}, {name: 'test.png', data: 'abc'});
+  Logger.log('Result: ' + JSON.stringify(result));
+
+  // Test with empty data string
+  Logger.log('Test 3: Empty data string');
+  result = uploadDocuments(testEmail, testApplicationId, {name: 'test.png', data: ''}, {name: 'test.png', data: 'abc'});
+  Logger.log('Result: ' + JSON.stringify(result));
+
+  Logger.log('=============================');
+}
+// ============================================
+// CAMPUS READY FOUNDATION - TESTIMONIAL REMINDERS
+// ============================================
+// Last updated: December 4, 2025
+// Purpose: Weekly digest of students ready for testimonial outreach
+//
+// Runs automatically every Monday at 8am PT (set up trigger after pasting)
+// Sends digest to hello@campusready.org
+
+const TESTIMONIAL_CONFIG = {
+  GRANT_RECIPIENTS_SHEET: 'Grant_Recipients',
+  NOTIFICATION_EMAIL: 'hello@campusready.org',
+
+  COLS: {
+    APPLICATION_ID: 0,    // A
+    STUDENT_NAME: 1,      // B
+    EMAIL: 2,             // C
+    COHORT_YEAR: 3,       // D
+    ITEMS_SELECTED: 9,    // J
+    START_DATE: 13,       // N
+    TESTIMONIAL_INVITED: 14,  // O
+    PHONE: 18             // S
+  }
+};
+
+/**
+ * Main function - checks for students ready for testimonial outreach
+ * and sends digest email to staff
+ */
+function sendTestimonialReminder() {
+  // Only run between June 15 and September 1
+  const today = new Date();
+  const month = today.getMonth(); // 0-indexed: Jan=0, Jun=5, Sep=8
+  const day = today.getDate();
+
+  const afterJune15 = (month > 5) || (month === 5 && day >= 15);
+  const beforeSept1 = (month < 8) || (month === 8 && day < 1);
+
+  if (!(afterJune15 && beforeSept1)) {
+    Logger.log('Outside testimonial outreach window (June 15 - September 1). Skipping.');
+    return;
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(TESTIMONIAL_CONFIG.GRANT_RECIPIENTS_SHEET);
+
+  if (!sheet) {
+    Logger.log('Grant_Recipients sheet not found');
+    return;
+  }
+
+  const readyStudents = [];
+
+  // Get all data (skip header row)
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    Logger.log('No data in Grant_Recipients');
+    return;
+  }
+
+  const data = sheet.getRange(2, 1, lastRow - 1, sheet.getLastColumn()).getValues();
+
+  // Check each student
+  data.forEach((row, index) => {
+    const startDate = row[TESTIMONIAL_CONFIG.COLS.START_DATE];
+    const testimonialInvited = row[TESTIMONIAL_CONFIG.COLS.TESTIMONIAL_INVITED];
+    const itemsSelected = row[TESTIMONIAL_CONFIG.COLS.ITEMS_SELECTED];
+    const studentName = row[TESTIMONIAL_CONFIG.COLS.STUDENT_NAME];
+
+    // Skip if no start date, already invited, or no name
+    if (!startDate || testimonialInvited || !studentName) {
+      return;
+    }
+
+    // Skip if they haven't completed kit selection
+    if (itemsSelected !== 'Yes') {
+      return;
+    }
+
+    // Check if start date has passed
+    const startDateObj = new Date(startDate);
+    if (startDateObj <= today) {
+      readyStudents.push({
+        name: studentName,
+        email: row[TESTIMONIAL_CONFIG.COLS.EMAIL],
+        phone: row[TESTIMONIAL_CONFIG.COLS.PHONE] || '',
+        startDate: Utilities.formatDate(startDateObj, Session.getScriptTimeZone(), 'MMM d, yyyy'),
+        cohort: row[TESTIMONIAL_CONFIG.COLS.COHORT_YEAR],
+        rowNumber: index + 2  // For reference (1-indexed, skip header)
+      });
+    }
+  });
+
+  // If no students ready, log and exit
+  if (readyStudents.length === 0) {
+    Logger.log('No students ready for testimonial outreach');
+    return;
+  }
+
+  // Build and send digest email
+  sendDigestEmail(readyStudents);
+  Logger.log('Testimonial reminder sent for ' + readyStudents.length + ' students');
+}
+
+/**
+ * Builds and sends the digest email
+ */
+function sendDigestEmail(students) {
+  const subject = 'Testimonial Outreach Ready: ' + students.length + ' student' + (students.length > 1 ? 's' : '');
+
+  // Build student list HTML
+  let studentListHTML = '';
+  students.forEach(student => {
+    studentListHTML += `
+      <tr>
+        <td style="padding: 12px; border-bottom: 1px solid #e5e7eb;">${student.name}</td>
+        <td style="padding: 12px; border-bottom: 1px solid #e5e7eb;">
+          <a href="mailto:${student.email}" style="color: #469E92;">${student.email}</a>
+        </td>
+        <td style="padding: 12px; border-bottom: 1px solid #e5e7eb;">${student.phone}</td>
+        <td style="padding: 12px; border-bottom: 1px solid #e5e7eb;">${student.startDate}</td>
+      </tr>
+    `;
+  });
+
+  const htmlBody = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto;">
+      <div style="background: linear-gradient(135deg, #469E92, #3a8178); padding: 24px; border-radius: 12px 12px 0 0;">
+        <h1 style="color: white; margin: 0; font-size: 24px;">Testimonial Outreach Ready</h1>
+      </div>
+
+      <div style="padding: 24px; background: #f9fafb; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 12px 12px;">
+        <p style="color: #374151; font-size: 16px; line-height: 1.6; margin-top: 0;">
+          The following <strong>${students.length}</strong> student${students.length > 1 ? 's have' : ' has'} arrived on campus and ${students.length > 1 ? 'are' : 'is'} ready for testimonial outreach:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; margin: 20px 0; background: white; border-radius: 8px; overflow: hidden; border: 1px solid #e5e7eb;">
+          <thead>
+            <tr style="background: #f3f4f6;">
+              <th style="padding: 12px; text-align: left; font-weight: 600; color: #374151;">Name</th>
+              <th style="padding: 12px; text-align: left; font-weight: 600; color: #374151;">Email</th>
+              <th style="padding: 12px; text-align: left; font-weight: 600; color: #374151;">Phone</th>
+              <th style="padding: 12px; text-align: left; font-weight: 600; color: #374151;">Start Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${studentListHTML}
+          </tbody>
+        </table>
+
+        <div style="background: #f0fdfa; border: 1px solid #99f6e4; border-radius: 8px; padding: 16px; margin-top: 20px;">
+          <p style="margin: 0; color: #0f766e; font-size: 14px; line-height: 1.5;">
+            <strong>Next steps:</strong><br>
+            1. Send each student the testimonial invitation email<br>
+            2. Mark the date in the "Testimonial Invited" column (O) in Grant_Recipients<br>
+            3. When they submit, add the URL and mark Release Signed / Gift Card Sent
+          </p>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const textBody = `Testimonial Outreach Ready\n\n` +
+    `${students.length} student${students.length > 1 ? 's have' : ' has'} arrived on campus and ${students.length > 1 ? 'are' : 'is'} ready for testimonial outreach:\n\n` +
+    students.map(s => `- ${s.name} | ${s.email} | ${s.phone} | Started ${s.startDate}`).join('\n') +
+    `\n\nNext steps:\n` +
+    `1. Send each student the testimonial invitation email\n` +
+    `2. Mark the date in the "Testimonial Invited" column (O) in Grant_Recipients\n` +
+    `3. When they submit, add the URL and mark Release Signed / Gift Card Sent`;
+
+  GmailApp.sendEmail(
+    TESTIMONIAL_CONFIG.NOTIFICATION_EMAIL,
+    subject,
+    textBody,
+    {
+      htmlBody: htmlBody,
+      name: 'Campus Ready Foundation'
+    }
+  );
+}
+/**
+ * Manual test function - run this to test without waiting for schedule
+ */
+function testTestimonialReminder() {
+  sendTestimonialReminder();
+}
+
+/**
+ * Sets up the weekly trigger - run once after pasting script
+ */
+function createTestimonialTrigger() {
+  // Remove any existing triggers for this function
+  const triggers = ScriptApp.getProjectTriggers();
+  triggers.forEach(trigger => {
+    if (trigger.getHandlerFunction() === 'sendTestimonialReminder') {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  });
+
+  // Create new weekly trigger - Mondays at 8am
+  ScriptApp.newTrigger('sendTestimonialReminder')
+    .timeBased()
+    .onWeekDay(ScriptApp.WeekDay.MONDAY)
+    .atHour(8)
+    .create();
+
+  Logger.log('Trigger created: sendTestimonialReminder will run every Monday at 8am');
+}
+
+// ============================================
+// TESTIMONIAL INVITE EMAIL SYSTEM
+// ============================================
+
+/**
+ * Send testimonial invitation emails to eligible students
+ * Menu: Fulfillment Tools > Send Testimonial Invites
+ */
+function sendTestimonialInvites() {
+  const ui = SpreadsheetApp.getUi();
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Grant_Recipients');
+
+  if (!sheet) {
+    ui.alert('Error', 'Grant_Recipients sheet not found', ui.ButtonSet.OK);
+    return;
+  }
+
+  const today = new Date();
+  const data = sheet.getDataRange().getValues();
+
+  // Find eligible students
+  const eligibleStudents = [];
+
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    const studentName = row[TESTIMONIAL_CONFIG.COLS.STUDENT_NAME];
+    const email = row[TESTIMONIAL_CONFIG.COLS.EMAIL];
+    const startDate = row[TESTIMONIAL_CONFIG.COLS.START_DATE];
+    const itemsSelected = row[TESTIMONIAL_CONFIG.COLS.ITEMS_SELECTED];
+    const testimonialInvited = row[TESTIMONIAL_CONFIG.COLS.TESTIMONIAL_INVITED];
+
+    // Skip if missing required data
+    if (!studentName || !email || !startDate) continue;
+
+    // Skip if already invited
+    if (testimonialInvited) continue;
+
+    // Skip if haven't completed kit selection
+    if (itemsSelected !== 'Yes') continue;
+
+    // Skip if start date hasn't passed
+    const startDateObj = new Date(startDate);
+    if (startDateObj > today) continue;
+
+    // Extract first name
+    const firstName = studentName.split(' ')[0];
+
+    eligibleStudents.push({
+      rowIndex: i + 1,
+      name: studentName,
+      firstName: firstName,
+      email: email,
+      startDate: Utilities.formatDate(startDateObj, Session.getScriptTimeZone(), 'MMM d, yyyy')
+    });
+  }
+
+  // If no eligible students, inform and exit
+  if (eligibleStudents.length === 0) {
+    ui.alert(
+      'No Students Ready',
+      'No students are currently eligible for testimonial invites.\n\n' +
+      'Students need:\n' +
+      '• Start date passed\n' +
+      '• Items Selected = Yes\n' +
+      '• Testimonial Invited = blank',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // Build confirmation message
+  let confirmMessage = `Ready to send testimonial invites to ${eligibleStudents.length} student(s):\n\n`;
+
+  eligibleStudents.forEach(student => {
+    confirmMessage += `• ${student.name} (started ${student.startDate})\n`;
+  });
+
+  confirmMessage += '\nThis will also send SMS reminders to check email.\n\nSend invites?';
+
+  // Show confirmation dialog
+  const response = ui.alert(
+    'Send Testimonial Invites',
+    confirmMessage,
+    ui.ButtonSet.YES_NO
+  );
+
+  if (response !== ui.Button.YES) {
+    ui.alert('Cancelled', 'No invites were sent.', ui.ButtonSet.OK);
+    return;
+  }
+
+  // Send emails and mark as invited
+  let successCount = 0;
+  let failCount = 0;
+  const timestamp = new Date();
+
+  eligibleStudents.forEach(student => {
+    try {
+      sendTestimonialEmailToStudent(student);
+
+      // Mark as invited with today's date
+      sheet.getRange(student.rowIndex, TESTIMONIAL_CONFIG.COLS.TESTIMONIAL_INVITED + 1)
+        .setValue(timestamp);
+
+      successCount++;
+    } catch (error) {
+      Logger.log(`Failed to send testimonial invite to ${student.email}: ${error}`);
+      failCount++;
+    }
+  });
+
+  // Show results
+  let resultMessage = `Testimonial invites sent: ${successCount}`;
+  if (failCount > 0) {
+    resultMessage += `\nFailed to send: ${failCount}`;
+  }
+  resultMessage += '\n\nRemember to send SMS messages manually using the template in Testimonial_Templates tab.';
+
+  ui.alert('Invites Sent', resultMessage, ui.ButtonSet.OK);
+}
+
+/**
+ * Send testimonial invitation email to individual student
+ */
+function sendTestimonialEmailToStudent(student) {
+  const subject = "You made it! How's it going?";
+
+  const textBody = `Hey ${student.firstName}!
+
+Congratulations, you made it to campus! We hope move-in went smoothly and you're getting settled in.
+
+We'd love to see how your space is coming together. If you're up for sharing a quick photo or short video of your setup, we'll send you a $50 Visa gift card as a thank-you.
+
+This is completely optional. We may use what you share on our website or social media to show future students what Campus Ready support looks like.
+
+If you'd like to participate:
+- Reply to this email with a photo or short video attached
+- A quick caption about your experience is welcome but not required
+
+That's it! We'll get your gift card on the way.
+
+Thanks for being part of Campus Ready. We're cheering you on!
+
+Warmly,
+The Campus Ready Team
+
+P.S. No pressure at all—we're just glad you're there.
+
+---
+By replying with your photo or video, you grant Campus Ready Foundation permission to use it on our website, social media, and promotional materials. We may include your first name and college. We will never share your contact information.`;
+
+  const htmlBody = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background-color: #f9fafb;">
+  <div style="max-width: 600px; margin: 0 auto; background: white; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
+
+    <!-- Header -->
+    <div style="background: linear-gradient(135deg, #469E92, #3a8178); padding: 32px; text-align: center;">
+    <h1 style="font-family: 'Playfair Display', Georgia, serif; color: white; margin: 0; font-size: 30px; font-weight: 700;">You Made It!</h1>
+    </div>
+
+    <!-- Body -->
+    <div style="padding: 32px;">
+      <p style="color: #374151; font-size: 16px; line-height: 1.6; margin-top: 0;">
+        Hey ${student.firstName}!
+      </p>
+
+      <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+        Congratulations, you made it to campus! We hope move-in went smoothly and you're getting settled in.
+      </p>
+
+      <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+        We'd love to see how your space is coming together. If you're up for sharing a quick photo or short video of your setup, we'll send you a <strong>$50 Visa gift card</strong> as a thank-you.
+      </p>
+
+      <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+        This is completely optional. We may use what you share on our website or social media to show future students what Campus Ready support looks like.
+      </p>
+
+      <!-- How to participate -->
+      <div style="background: #f0fdfa; border: 1px solid #99f6e4; border-radius: 12px; padding: 20px; margin: 24px 0;">
+        <p style="color: #0f766e; font-size: 16px; font-weight: 600; margin: 0 0 12px 0;">
+          If you'd like to participate:
+        </p>
+        <p style="color: #374151; font-size: 16px; line-height: 1.6; margin: 0;">
+          Reply to this email with a photo or short video attached, and quick caption about your experience.
+        </p>
+      </div>
+
+      <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+        That's it! We'll get your gift card on the way.
+      </p>
+
+      <p style="color: #374151; font-size: 16px; line-height: 1.6;">
+        Thanks for being part of Campus Ready. We're cheering you on!
+      </p>
+
+      <!-- Signature -->
+      <div style="margin-top: 32px; padding-top: 24px; border-top: 1px solid #e5e7eb;">
+        <p style="color: #374151; font-size: 16px; margin: 0;">Warmly,</p>
+        <p style="color: #374151; font-size: 16px; font-weight: 600; margin: 4px 0 0 0;">The Campus Ready Team</p>
+      </div>
+
+      <p style="color: #6b7280; font-size: 14px; font-style: italic; margin-top: 24px;">
+        P.S. No pressure at all—we're just glad you're there.
+      </p>
+    </div>
+
+    <!-- Fine Print / Release -->
+    <div style="padding: 20px 32px; background: #f9fafb; border-top: 1px solid #e5e7eb;">
+      <p style="color: #6b7280; font-size: 12px; line-height: 1.5; margin: 0;">
+        By replying with your photo or video, you grant Campus Ready Foundation permission to use it on our website, social media, and promotional materials. We may include your first name and college. We will never share your contact information.
+      </p>
+    </div>
+
+  </div>
+</body>
+</html>`;
+
+  GmailApp.sendEmail(
+    student.email,
+    subject,
+    textBody,
+    {
+      htmlBody: htmlBody,
+      name: 'Campus Ready Foundation',
+      replyTo: 'hello@campusready.org'
+    }
+  );
+
+  Logger.log(`Testimonial invite sent to ${student.email} (${student.name})`);
+}
+/**
+ * Test function - sends testimonial invite to yourself
+ */
+function testTestimonialEmail() {
+  const testStudent = {
+    firstName: 'Eric',
+    name: 'Eric Lilavois',
+    email: 'elilavois@gmail.com'
+  };
+
+  sendTestimonialEmailToStudent(testStudent);
+  Logger.log('Test email sent to ' + testStudent.email);
+}


### PR DESCRIPTION
This commit does two things together: it brings the Apps Script under git for the first time, and it lands the Phase 2 follow-up that persists the new college_id field from the picker into the Master sheet at column AX (50).

Why now: the Apps Script is the server side of the application form. Having it untracked while the form side is fully tracked has been a discipline gap — every form change has been a reviewable diff, every Apps Script change has been invisible. Phase 2 introducing a new field the script needs to handle is the right moment to close that gap.

The initial check-in covers all four .gs files as they exist today:

  Application_Main_Script.gs (1,749 lines)
    The submission entry point. Modified in this commit (see below).

  Application_Admin_Script.gs (980 lines)
    Staff-side helpers: bulk operations, exports, status flips.

  Board_Score_Import.gs (524 lines)
    Imports board reviewer essay scores from the three scoring
    sheets into the Master tab.

  Grant_Fulfillment_Script.gs (2,463 lines)
    Post-award tracking: shipping, item delivery, communications.

Application_Main_Script.gs changes in this commit:

  - Add COLLEGE_ID: 50 to the COL constant (column AX), with an inline comment documenting that columns AN through AW are scoring and derived data managed outside this script (Distance Points, Total Score, New Rank, Avg Essay Score, etc.) and the row writer must not touch them.

  - In writeMasterRowPending, write college_id to column AX via a separate single-cell setValue call AFTER the main row write. This keeps the row array at 39 columns and structurally prevents the writer from ever overwriting the scoring block. Only writes when data.college_id is truthy, so re-queued rows from the 2026 cohort (which lacked a UNITID) leave the cell untouched.

  - Annotate the college_address line with a comment noting it is intentionally empty for 2027+ applications because the field was removed in Phase 2. Defensive documentation so future maintainers don't try to "fix" the empty column.

  - Rename the PDF field label "Address" to "College Location" in buildPDFHTML. The PDF still shows the city/state/ZIP joined string, but the label now accurately reflects what's there rather than implying a street address we no longer collect.

The other three .gs files are unchanged from their working state and are checked in here for version-history reasons only.

Manual steps completed alongside this commit (not in code):
  - "College UNITID" header added at cell AX1 of the Master sheet.
  - Column 38 header renamed from "Internal Notes" to "Processing Timestamp" so it matches what the script has always used that column for. Closes the prior naming-vs-behavior gap.

Distance scoring continues to read college_zip from column V and is unaffected by this change. The picker provides an authoritative ZIP from IPEDS, so the scoring input is now clean by construction.